### PR TITLE
fix: booth detail 페이지 내 상단 네브 바 수정

### DIFF
--- a/src/components/nav-bar/NavBar.tsx
+++ b/src/components/nav-bar/NavBar.tsx
@@ -3,6 +3,7 @@ import SearchIcon from '@/assets/icons/search.svg?react';
 import BackIcon from '@/assets/icons/left-arrow.svg?react';
 import LogoIcon from '@/assets/icons/Logo_Sample.svg?react';
 import HeartIcon from '@/assets/icons/favorite.svg?react';
+import CloseIcon from '@/assets/icons/close-black.svg?react';
 
 import { NavBarProps, SearchNavBarProps } from './NavBar.types';
 import { useNavigate } from 'react-router-dom';
@@ -25,9 +26,11 @@ const NavBar: React.FC<NavBarProps> = ({
   isBack = false,
   isSearch = false,
   isFavorite = false,
+  isClose = false,
   title,
   onSearchClick,
   onFavoriteClick,
+  onCloseClick,
   backPath = -1,
   opacity = false,
 }) => {
@@ -75,6 +78,14 @@ const NavBar: React.FC<NavBarProps> = ({
             onClick={onSearchClick}
           />
         )}
+        {isClose && (
+          <CloseIcon
+            style={{ cursor: 'pointer' }}
+            width={'0.85rem'}
+            height={'0.85rem'}
+            onClick={onCloseClick}
+          />
+        )}
       </S.RightSection>
     </S.Container>
   );
@@ -113,11 +124,11 @@ const SearchNavBar: React.FC<SearchNavBarProps> = ({
 
   return (
     <S.Container style={{ gap: '0.75rem' }}>
-      <BackIcon width={'1.5rem'} height={'1.5rem'} onClick={handleBack} />
+      <BackIcon width={'0.85rem'} height={'0.85rem'} onClick={handleBack} />
       <S.SearchWrapper htmlFor="search">
         <input id="search" placeholder={placeholder} onChange={onChange} value={value || ''} />
         <S.Btn whileTap={{ scale: 0.92, backgroundColor: '#212526' }}>
-          <SearchIcon width={'1.5rem'} height={'1.5rem'} onClick={onClick} />
+          <SearchIcon width={'0.95rem'} height={'0.95rem'} onClick={onClick} />
         </S.Btn>
       </S.SearchWrapper>
     </S.Container>

--- a/src/components/nav-bar/NavBar.types.ts
+++ b/src/components/nav-bar/NavBar.types.ts
@@ -5,9 +5,11 @@ export interface NavBarProps {
   isBack?: boolean;
   isSearch?: boolean;
   isFavorite?: boolean;
+  isClose?: boolean;
   title?: string;
   onSearchClick?: () => void;
   onFavoriteClick?: () => void;
+  onCloseClick?: () => void;
   backPath?: number | string;
   opacity?: boolean;
 }

--- a/src/pages/booth/BoothDetail.tsx
+++ b/src/pages/booth/BoothDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { NavBar } from '@/components/nav-bar';
 import * as S from './BoothDetail.styles';
 import { BoothInfo, BoothLocation, MenuList } from '@/features/booth';
@@ -11,9 +11,14 @@ import { useFavorites } from '@/hooks/useFavorites';
 export default function BoothDetail() {
   const { id } = useParams();
   const location = useLocation();
+  const navigate = useNavigate();
   const fromRef = useRef(location.state?.from || '/booth');
   const booth = BOOTH_LIST.find((booth) => booth.id === Number(id)); // ✅ 타입 일치
   const { handleToggleFavorite, isFavorited } = useFavorites();
+
+  const handleCloseClick = () => {
+    navigate('/booth');
+  };
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -27,7 +32,13 @@ export default function BoothDetail() {
 
   return (
     <S.Container>
-      <NavBar isBack title="주점" backPath={fromRef.current} />
+      <NavBar
+        isBack
+        isClose
+        title="주점 정보"
+        backPath={fromRef.current}
+        onCloseClick={handleCloseClick}
+      />
       <S.BackgroundImg src={booth.posterImage} />
       <S.FavoriteButton
         onClick={(e) => handleToggleFavorite(booth.id, e)}


### PR DESCRIPTION
## 구현 내용 
- 주점 상세 페이지 상단 네브바 아이콘 추가
- 아이콘 별 경로 수정
  - <: 직전 페이지로
  - X: 주점 메인 페이지로 이동

## 스크린샷
<img width="315" height="331" alt="image" src="https://github.com/user-attachments/assets/c694e7ba-198f-45d6-b0f8-95eb8d430804" />


## 검토가 필요한 사항
- [ ] 주점에서 넘어가는 map/search 페이지 내 < 경로  