### PR TITLE
fix: api 응답 필드명 camelCase 적용

### DIFF
--- a/src/services/boothService.ts
+++ b/src/services/boothService.ts
@@ -49,8 +49,8 @@ const transformPubToBootn = async (pub: PubApiResponse): Promise<Booth> => {
       affiliation: pub.affiliation,
       pubName: pub.name,
       takeout: pub.takeout,
-      profileImage: pub.profile_image,
-      posterImage: pub.poster_image,
+      profileImage: pub.profileImage,
+      posterImage: pub.posterImage,
       menu,
     } as Booth;
   } catch {
@@ -64,8 +64,8 @@ const transformPubToBootn = async (pub: PubApiResponse): Promise<Booth> => {
       affiliation: pub.affiliation,
       pubName: pub.name,
       takeout: pub.takeout,
-      profileImage: pub.profile_image,
-      posterImage: pub.poster_image,
+      profileImage: pub.profileImage,
+      posterImage: pub.posterImage,
       menu: boothData
         ? JSON.parse(JSON.stringify(boothData.menu))
         : { main: [], side: [], sub: [] },

--- a/src/types/booth.types.ts
+++ b/src/types/booth.types.ts
@@ -29,8 +29,8 @@ export interface PubApiResponse {
   affiliation: string;
   name: string;
   takeout: boolean;
-  profile_image: string;
-  poster_image: string;
+  profileImage: string;
+  posterImage: string;
 }
 
 export interface PubListResponse {


### PR DESCRIPTION
## 수정 내용
- 주점 응답 필드명 camelCase 적용 (기존: 스네이크)
- profile_image, poster_image -> profileImage, posterImage