### PR TITLE
fix: carousel padding change

### DIFF
--- a/src/features/performance/NewCarousel.styles.ts
+++ b/src/features/performance/NewCarousel.styles.ts
@@ -16,18 +16,13 @@ export const CarouselWrapper = styled.div`
     flex-wrap: nowrap;
   }
 
-  /* slick-slide 스타일링 */
-  .slick-slide {
-    padding: 0 0.75rem;
-  }
-
   .slick-list {
     overflow: visible;
+    padding: 0 20px;
   }
 `;
 
 export const CarouselItem = styled.div`
-  flex-shrink: 0;
   scroll-snap-align: start;
   display: flex;
   flex-direction: column;

--- a/src/features/performance/NewCarousel.tsx
+++ b/src/features/performance/NewCarousel.tsx
@@ -35,11 +35,11 @@ export default function NewCarousel({ data, onIndexChange, onArtistClick }: NewC
     dots: false,
     infinite: false,
     speed: 500,
-    slidesToShow: 1,
-    slidesToScroll: 1,
+    slidesToShow: 1.5,
+    slidesToScroll: 1.5,
     arrows: false,
-    centerMode: false,
-    variableWidth: true,
+    centerMode: true,
+    variableWidth: false,
     initialSlide: 0,
 
     beforeChange: () => {

--- a/src/pages/performance/Performance.tsx
+++ b/src/pages/performance/Performance.tsx
@@ -83,10 +83,16 @@ export default function Performance() {
         {performances.length > 0 && (
           <S.ProgressContainer>
             <S.ProgressBar>
-              <S.ProgressFill
-                width={`${(1 / performances.length) * 100}%`}
-                left={`${(currentIndex / performances.length) * 100}%`}
-              />
+              {(() => {
+                const slidesToShow = 1.5;
+                const adjustedLength = performances.length - slidesToShow + 1;
+                return (
+                  <S.ProgressFill
+                    width={`${100 / adjustedLength}%`}
+                    left={`${(currentIndex / (adjustedLength - 1)) * (100 - 100 / adjustedLength)}%`}
+                  />
+                );
+              })()}
             </S.ProgressBar>
           </S.ProgressContainer>
         )}


### PR DESCRIPTION
## 🔥 PR 제목  
- fix: carousel padding change

## 📌 작업 내용  
- carousel 오른쪽 패딩 삭제
  -> vaiableMode : false (자동 패딩 값 삭제)
  -> centerMode : true (가운데로 조정)
  -> slidesToShow,Scroll : centerMode로 설정을 해놔서 피그마와 똑같이 보여지게 하기 위해 1.5로 변경

- ProgressFill 값 다시 계산

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 테스트 완료  
- [x] 필요한 경우 문서를 업데이트했는지 확인  
- [x] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

https://github.com/user-attachments/assets/e9b2d6b0-dbe5-4081-aed8-56c210ddd274


## 🚀 테스트 방법  

## 💡 추가 논의할 사항  
- ProgressFill 계산법이 이해가 잘 안가서 똑같이 움직이는 구조로 바꾸지는 못했는데 이 부분은 나중에 수정해주십쇼!

## 🙏 리뷰어에게 한마디  