### PR TITLE
feat: 운세 결과 페이지 내 카드 뒷면 애니메이션 추가

### DIFF
--- a/src/pages/main/fortune/FortuneResult.styles.ts
+++ b/src/pages/main/fortune/FortuneResult.styles.ts
@@ -42,7 +42,7 @@ export const CardContainer = styled.div`
 `;
 
 // 회전하는 박스
-export const CardInner = styled.button<{ $isFlipped: boolean }>`
+export const CardInner = styled.button<{ $isFlipped: boolean; $isVisible: boolean }>`
   -webkit-tap-highlight-color: transparent;
   appearance: none;
   border: 0;
@@ -52,8 +52,11 @@ export const CardInner = styled.button<{ $isFlipped: boolean }>`
   width: 295px;
   height: 440px;
   transform-style: preserve-3d;
+  transform: ${({ $isVisible }) => ($isVisible ? 'scale(1)' : 'scale(0)')};
+  opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
   transition:
-    transform 0.8s cubic-bezier(0.2, 0.7, 0.2, 1),
+    transform 1.8s cubic-bezier(0.2, 0.7, 0.2, 1),
+    opacity 1.8s cubic-bezier(0.2, 0.7, 0.2, 1),
     box-shadow 0.3s ease;
   box-shadow:
     0 0 20px 6px ${({ theme }) => theme.colors.secondary.DS_Card}50,
@@ -67,11 +70,17 @@ export const CardInner = styled.button<{ $isFlipped: boolean }>`
   `}
 
   &:hover {
-    transform: ${(props) => (props.$isFlipped ? 'rotateY(180deg) scale(1.02)' : 'scale(1.02)')};
+    transform: ${(props) => {
+      const baseScale = props.$isVisible ? 'scale(1.02)' : 'scale(0)';
+      return props.$isFlipped ? 'rotateY(180deg) scale(1.02)' : baseScale;
+    }};
   }
 
   &:active {
-    transform: ${(props) => (props.$isFlipped ? 'rotateY(180deg) scale(0.98)' : 'scale(0.98)')};
+    transform: ${(props) => {
+      const baseScale = props.$isVisible ? 'scale(0.98)' : 'scale(0)';
+      return props.$isFlipped ? 'rotateY(180deg) scale(0.98)' : baseScale;
+    }};
   }
 
   &:focus-visible {

--- a/src/pages/main/fortune/FortuneResult.tsx
+++ b/src/pages/main/fortune/FortuneResult.tsx
@@ -18,6 +18,7 @@ export default function FortuneResult() {
   const navigate = useNavigate();
   const location = useLocation();
   const [isFlipped, setIsFlipped] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
 
   const state = location.state as LocationState;
   const selectedCardIndex = state?.selectedCardIndex ?? 0;
@@ -38,6 +39,7 @@ export default function FortuneResult() {
 
   useEffect(() => {
     setIsNav(false);
+    setTimeout(() => setIsVisible(true), 600);
     return () => {
       setIsNav(true);
     };
@@ -55,7 +57,12 @@ export default function FortuneResult() {
         </S.Title>
 
         <S.CardContainer>
-          <S.CardInner $isFlipped={isFlipped} onClick={handleCardClick} aria-pressed={isFlipped}>
+          <S.CardInner
+            $isFlipped={isFlipped}
+            $isVisible={isVisible}
+            onClick={handleCardClick}
+            aria-pressed={isFlipped}
+          >
             <S.CardFaceFront>
               <img
                 src={FortuneCardBack}


### PR DESCRIPTION
## 구현 내용
- 선택된 운세 카드 확인 페이지 내 결과 카드 애니메이션 추가