### PR TITLE
fix: 주점 페이지(검색, 상세) 내 디자인 수정 사항 반영

### DIFF
--- a/src/components/nav-bar/NavBar.tsx
+++ b/src/components/nav-bar/NavBar.tsx
@@ -28,6 +28,7 @@ const NavBar: React.FC<NavBarProps> = ({
   isFavorite = false,
   isClose = false,
   hideLeft = false,
+  hideRight = false,
   title,
   onSearchClick,
   onFavoriteClick,
@@ -71,21 +72,25 @@ const NavBar: React.FC<NavBarProps> = ({
 
       {title && <S.Title $opacity={opacity}>{title}</S.Title>}
       <S.RightSection $opacity={opacity}>
-        {isSearch && (
-          <SearchIcon
-            style={{ cursor: 'pointer' }}
-            width={'1.5rem'}
-            height={'1.5rem'}
-            onClick={onSearchClick}
-          />
-        )}
-        {isClose && (
-          <CloseIcon
-            style={{ cursor: 'pointer' }}
-            width={'0.85rem'}
-            height={'0.85rem'}
-            onClick={onCloseClick}
-          />
+        {!hideRight && (
+          <>
+            {isSearch && (
+              <SearchIcon
+                style={{ cursor: 'pointer' }}
+                width={'1.5rem'}
+                height={'1.5rem'}
+                onClick={onSearchClick}
+              />
+            )}
+            {isClose && (
+              <CloseIcon
+                style={{ cursor: 'pointer' }}
+                width={'0.85rem'}
+                height={'0.85rem'}
+                onClick={onCloseClick}
+              />
+            )}
+          </>
         )}
       </S.RightSection>
     </S.Container>

--- a/src/components/nav-bar/NavBar.types.ts
+++ b/src/components/nav-bar/NavBar.types.ts
@@ -7,6 +7,7 @@ export interface NavBarProps {
   isFavorite?: boolean;
   isClose?: boolean;
   hideLeft?: boolean;
+  hideRight?: boolean;
   title?: string;
   onSearchClick?: () => void;
   onFavoriteClick?: () => void;

--- a/src/pages/booth/BoothDetail.styles.ts
+++ b/src/pages/booth/BoothDetail.styles.ts
@@ -76,3 +76,15 @@ export const FavoriteButton = styled.button<{ $isFavorited: boolean }>`
   z-index: 10;
   transition: all 0.2s ease;
 `;
+
+export const LoadingText = styled.div`
+  display: flex;
+  height: 1.625rem;
+  padding: 0.0625rem 0.5rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.625rem;
+  margin-top: 320px;
+  ${(props) => props.theme.fonts.body.medium500};
+  color: ${(props) => props.theme.colors.primary.violet};
+`;

--- a/src/pages/booth/BoothDetail.tsx
+++ b/src/pages/booth/BoothDetail.tsx
@@ -29,12 +29,12 @@ export default function BoothDetail() {
       <S.Container>
         <NavBar
           isBack
-          isClose
+          hideRight
           title="주점 정보"
           backPath={fromRef.current}
           onCloseClick={handleCloseClick}
         />
-        <div>주점 정보를 불러오는 중...</div>
+        <S.LoadingText>주점 정보를 불러오는 중...</S.LoadingText>
       </S.Container>
     );
   }
@@ -42,14 +42,8 @@ export default function BoothDetail() {
   if (error || !booth) {
     return (
       <S.Container>
-        <NavBar
-          isBack
-          isClose
-          title="주점 정보"
-          backPath={fromRef.current}
-          onCloseClick={handleCloseClick}
-        />
-        <div>{error || '주점을 찾을 수 없습니다.'}</div>
+        <NavBar isBack hideRight title="주점 정보" backPath={fromRef.current} />
+        <S.LoadingText>{error || '주점을 찾을 수 없습니다.'}</S.LoadingText>
       </S.Container>
     );
   }
@@ -58,13 +52,7 @@ export default function BoothDetail() {
 
   return (
     <S.Container>
-      <NavBar
-        isBack
-        isClose
-        title="주점 정보"
-        backPath={fromRef.current}
-        onCloseClick={handleCloseClick}
-      />
+      <NavBar isBack hideRight title="주점 정보" backPath={fromRef.current} />
       <S.BackgroundImg src={booth.posterImage} />
       <S.FavoriteButton
         onClick={(e) => handleToggleFavorite(booth.id, e)}

--- a/src/pages/booth/search/BoothSearch.styles.ts
+++ b/src/pages/booth/search/BoothSearch.styles.ts
@@ -111,29 +111,6 @@ export const BoothItemWrapper = styled.div`
   gap: 0.75rem;
 `;
 
-export const FavoriteButton = styled.button<{ $isFavorited: boolean }>`
-  flex-shrink: 0;
-  gap: 0.4375rem;
-  border: ${({ $isFavorited, theme }) =>
-    $isFavorited ? 'none' : `1px solid ${theme.colors.primary.violet}`};
-  background: ${({ $isFavorited, theme }) => ($isFavorited ? theme.colors.primary.violet : 'none')};
-  border-radius: 0.75rem;
-  width: 3.375rem;
-  height: 4.5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.75rem;
-  color: ${({ $isFavorited, theme }) => ($isFavorited ? '#ffffff' : theme.colors.primary.violet)};
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:active {
-    transform: scale(0.95);
-  }
-`;
-
 export const EmptyState = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/pages/booth/search/BoothSearch.tsx
+++ b/src/pages/booth/search/BoothSearch.tsx
@@ -3,10 +3,6 @@ import { ImageTextFrameWithOrganization } from '@/components/image-text-frame';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useBooths } from '@/hooks/useBooth';
 import { Fragment, useState, useMemo } from 'react';
-import { useFavorites } from '@/hooks/useFavorites';
-
-import FavoriteOn from '@/assets/icons/favorite-on.svg?react';
-import FavoriteOff from '@/assets/icons/favorite-off.svg?react';
 import SearchIcon from '@/assets/icons/search-gray.svg?react';
 import CloseIcon from '@/assets/icons/close-search.svg?react';
 
@@ -15,7 +11,6 @@ import * as S from './BoothSearch.styles';
 export default function BoothSearch() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { handleToggleFavorite, isFavorited } = useFavorites();
   const { booths, loading } = useBooths();
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -45,7 +40,7 @@ export default function BoothSearch() {
 
   return (
     <S.Container>
-      <NavBar hideLeft isClose title="주점 검색" onCloseClick={handleCloseClick} />
+      <NavBar isBack hideRight title="주점 검색" onCloseClick={handleCloseClick} />
       <S.Main>
         <S.Content>
           <S.SearchSection>
@@ -90,8 +85,6 @@ export default function BoothSearch() {
               <S.ResultsList>
                 <S.ResultItem>
                   {filteredBooths.map((booth) => {
-                    const isBoothFavorited = isFavorited(booth.id);
-
                     return (
                       <Fragment key={booth.id}>
                         <S.BoothItemWrapper>
@@ -108,14 +101,6 @@ export default function BoothSearch() {
                               })
                             }
                           />
-                          <S.FavoriteButton
-                            onClick={(e) => handleToggleFavorite(booth.id, e)}
-                            $isFavorited={isBoothFavorited}
-                            aria-label={isBoothFavorited ? '찜 완료' : '찜하기'}
-                          >
-                            {isBoothFavorited ? <FavoriteOn /> : <FavoriteOff />}
-                            {isBoothFavorited ? '찜 완료' : '찜하기'}
-                          </S.FavoriteButton>
                         </S.BoothItemWrapper>
                         <S.HorizontalLine />
                       </Fragment>


### PR DESCRIPTION
## 구현 내용
- 주점 상세 페이지 
    - (x) 버튼 제거 -> navbar 내 hideright 필드 추가
- 주점 검색 페이지 
    - (x) 버튼 제거
    - 좋아요 버튼 제거 (관련 스타일 변수 제거)
   

## 스크린샷
<img width="200" alt="image" src="https://github.com/user-attachments/assets/c6429c8d-b3fe-4c01-b9e8-ec9f8f10b44a" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/b51893ce-cc9a-4493-8f48-9eea551a94a5" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/32c6cb68-12ee-4f60-83cc-d64ff8658b7d" />
