### PR TITLE
fix: 주점 메뉴 카테고리 및 로딩 조건문 제거

### DIFF
--- a/src/features/booth/components/BoothInfo.tsx
+++ b/src/features/booth/components/BoothInfo.tsx
@@ -6,9 +6,7 @@ import PubBeerIcon from '@/assets/icons/pub_beer.svg?react';
 import TimeIcon from '@/assets/icons/time_pub.svg?react';
 
 export default function BoothInfo({ id }: { id: number }) {
-  const { booth, loading, error } = useBooth(id);
-
-  if (loading) return <div>로딩 중...</div>;
+  const { booth, error } = useBooth(id);
   if (error || !booth) return <div>주점 정보를 찾을 수 없습니다.</div>;
   return (
     <S.Container>

--- a/src/features/booth/components/BoothList.tsx
+++ b/src/features/booth/components/BoothList.tsx
@@ -17,7 +17,7 @@ interface BoothListProps {
 export default function BoothList({ showFavoritesOnly = false }: BoothListProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const { booths, loading, error } = useBooths();
+  const { booths, error } = useBooths();
 
   // 찜하기 기능 상태 관리 추가 (localStorage)
   const [favorites, setFavorites] = useState<number[]>(() => {
@@ -42,14 +42,6 @@ export default function BoothList({ showFavoritesOnly = false }: BoothListProps)
   const displayBooths = showFavoritesOnly
     ? booths.filter((booth) => favorites.includes(booth.id))
     : booths;
-
-  if (loading) {
-    return (
-      <S.Container>
-        <div>주점 정보를 불러오는 중...</div>
-      </S.Container>
-    );
-  }
 
   if (error) {
     return (

--- a/src/features/booth/components/MenuList.tsx
+++ b/src/features/booth/components/MenuList.tsx
@@ -7,9 +7,8 @@ const MENU_CATEGORY = ['메인 메뉴', '사이드 메뉴', '음료'];
 
 export default function MenuList({ id }: { id: number }) {
   const [activeTab, setActiveTab] = useState<string>('');
-  const { booth, loading, error } = useBooth(id);
+  const { booth, error } = useBooth(id);
 
-  if (loading) return <div>메뉴 정보를 불러오는 중...</div>;
   if (error || !booth) return <div>메뉴 정보를 찾을 수 없습니다.</div>;
   return (
     <>

--- a/src/pages/booth/BoothDetail.tsx
+++ b/src/pages/booth/BoothDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useParams, useLocation, useNavigate } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import { NavBar } from '@/components/nav-bar';
 import * as S from './BoothDetail.styles';
 import { BoothInfo, BoothLocation, MenuList } from '@/features/booth';
@@ -11,33 +11,13 @@ import { useBooth } from '@/hooks/useBooth';
 export default function BoothDetail() {
   const { id } = useParams();
   const location = useLocation();
-  const navigate = useNavigate();
   const fromRef = useRef(location.state?.from || '/booth');
-  const { booth, loading, error } = useBooth(Number(id) || 0);
+  const { booth, error } = useBooth(Number(id) || 0);
   const { handleToggleFavorite, isFavorited } = useFavorites();
-
-  const handleCloseClick = () => {
-    navigate('/booth');
-  };
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
-
-  if (loading) {
-    return (
-      <S.Container>
-        <NavBar
-          isBack
-          hideRight
-          title="주점 정보"
-          backPath={fromRef.current}
-          onCloseClick={handleCloseClick}
-        />
-        <S.LoadingText>주점 정보를 불러오는 중...</S.LoadingText>
-      </S.Container>
-    );
-  }
 
   if (error || !booth) {
     return (


### PR DESCRIPTION
## 구현 내용
- 주점 관련 페이지 (상세, 검색, 찜목록, 주점 목록) 간 이동 중 발생하는 로딩 텍스트 제거 
- loading 관련 항목 전체 제거 (error처리만 남김)
- 주점 메뉴 카테고리 변경 (음료 -> 기타)