### PR TITLE
fix: optimize performance page layout for wider viewport

### DIFF
--- a/src/features/performance/NewCarousel.styles.ts
+++ b/src/features/performance/NewCarousel.styles.ts
@@ -8,7 +8,7 @@ export const Container = styled.div`
 
 export const CarouselWrapper = styled.div`
   width: 100dvw;
-  padding-left: 1.25rem;
+  max-width: 21rem;
 
   /* slick-track 스타일링 */
   .slick-track {
@@ -66,7 +66,8 @@ export const NorthStar = styled.div`
 
 export const VerticalLine = styled.div`
   width: 0.0625rem;
-  height: 4.5rem;
+  height: calc(100dvh - 45rem);
+  max-height: 10rem;
   background: ${(props) => props.theme.colors.primary.violet};
 `;
 

--- a/src/pages/performance/Performance.styles.ts
+++ b/src/pages/performance/Performance.styles.ts
@@ -5,7 +5,8 @@ export const PerformanceContainer = styled.div`
   width: 100%;
   height: auto;
   position: relative;
-  margin-bottom: 5.37rem;
+
+  /* margin-bottom: 5.37rem; */
 `;
 
 export const Header = styled.header`
@@ -39,7 +40,7 @@ export const Fullscreen = styled.main`
   position: relative;
   overflow: hidden auto;
   min-height: 0;
-  padding-bottom: 5rem;
+  height: calc(100dvh - 5.5rem);
 `;
 
 export const InfoWrap = styled.div`
@@ -77,11 +78,12 @@ export const HelpIconStyled = styled(HelpIcon)`
 export const Carousel = styled.div<{ $isFirstDay?: boolean }>`
   display: flex;
   align-items: center;
-  justify-content: ${(props) => (props.$isFirstDay ? 'center' : 'flex-start')};
+  justify-content: center; /* ${(props) => (props.$isFirstDay ? 'center' : 'flex-start')}; */
   gap: 0.75rem;
   width: 100%;
-  margin-top: 1rem;
+  margin-top: 0;
   overflow: visible;
+  flex: 1;
 `;
 
 export const TableNoteWrap = styled.div`
@@ -107,22 +109,15 @@ export const NoteText = styled.p`
 
 export const TimeTableButton = styled.button`
   display: flex;
-  padding: 0.25rem 0.75rem;
   justify-content: center;
   align-items: center;
-  gap: 0.375rem;
-  margin-top: 2rem;
+  margin: 0.8rem 1.4rem 2rem;
   align-self: flex-end;
-  margin-right: 1.25rem;
-  ${(props) => props.theme.fonts.body.xsmall500};
+  ${(props) => props.theme.fonts.body.xsmall600};
   color: ${(props) => props.theme.colors.primary.violet};
   text-align: center;
   text-decoration-line: underline;
   text-decoration-style: solid;
-  text-decoration-skip-ink: auto;
-  text-decoration-thickness: auto;
-  text-underline-offset: auto;
-  text-underline-position: from-font;
   background: transparent;
   border: none;
   cursor: pointer;


### PR DESCRIPTION
## 🔥 PR 제목  

fix: optimize performance page layout for wider viewport

## 📌 작업 내용  

넓은 뷰포트 화면 가진 디바이스 (아이패드, 폴드 등) 에서 performance 캐러셀 이쁘게 보이도록 수정

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

|기존|수정|
|-|-|
|<img width="729" height="1046" alt="image" src="https://github.com/user-attachments/assets/499beb62-21df-49cd-866c-570f712fd541" />|<img width="728" height="1045" alt="image" src="https://github.com/user-attachments/assets/652042ee-9fd0-4325-b284-f9ea42037d4a" />|


## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  