### PR TITLE
fix: 주점 관련 페이지 api 수정 및 에러 페이지 리다이렉션

### DIFF
--- a/src/features/booth/components/BoothInfo.tsx
+++ b/src/features/booth/components/BoothInfo.tsx
@@ -1,13 +1,26 @@
 import * as S from './BoothInfo.styles';
 import { newlineToBr } from '@/utils/newlineToBr';
 import { useBooth } from '@/hooks/useBooth';
+import { useNavigate } from 'react-router-dom';
 import { OPERATING_HOURS } from '@/constants/booth/operating-hours';
 import PubBeerIcon from '@/assets/icons/pub_beer.svg?react';
 import TimeIcon from '@/assets/icons/time_pub.svg?react';
 
 export default function BoothInfo({ id }: { id: number }) {
   const { booth, error } = useBooth(id);
-  if (error || !booth) return <div>주점 정보를 찾을 수 없습니다.</div>;
+  const navigate = useNavigate();
+
+  if (error || !booth) {
+    navigate('/error', {
+      state: {
+        mainText: '서버가 힘들어하고 있어요.',
+        subText: '멋사가 금방 고쳐올테니, 잠시 후에 다시 와주세요!',
+        showBackButton: true,
+        showHomeButton: true,
+      },
+    });
+    return null;
+  }
   return (
     <S.Container>
       <S.ImageBtnFrame>

--- a/src/features/booth/components/BoothList.styles.ts
+++ b/src/features/booth/components/BoothList.styles.ts
@@ -121,6 +121,7 @@ export const EmptyText = styled.p`
   color: ${(props) => props.theme.colors.grayScale.gy400};
   text-align: center;
   white-space: pre-line;
+  margin-top: 50px;
 `;
 
 export const TabButton = styled.button<{ $active: boolean }>`

--- a/src/features/booth/components/BoothList.tsx
+++ b/src/features/booth/components/BoothList.tsx
@@ -44,11 +44,15 @@ export default function BoothList({ showFavoritesOnly = false }: BoothListProps)
     : booths;
 
   if (error) {
-    return (
-      <S.Container>
-        <div>{error}</div>
-      </S.Container>
-    );
+    navigate('/error', {
+      state: {
+        mainText: '서버가 힘들어하고 있어요.',
+        subText: '멋사가 금방 고쳐올테니, 잠시 후에 다시 와주세요!',
+        showBackButton: true,
+        showHomeButton: true,
+      },
+    });
+    return null;
   }
 
   return (

--- a/src/features/booth/components/BoothList.tsx
+++ b/src/features/booth/components/BoothList.tsx
@@ -70,8 +70,8 @@ export default function BoothList({ showFavoritesOnly = false }: BoothListProps)
       {showFavoritesOnly && displayBooths.length === 0 ? (
         <S.EmptyState>
           <S.EmptyText>
-            아직 찜한 주점이 없습니다.{'\n'}
-            마음에 드는 주점을 찜해보세요!
+            찜한 주점이 없어요.{'\n'}
+            원하는 주점의 찜하기 버튼을 눌러보세요!
           </S.EmptyText>
         </S.EmptyState>
       ) : (

--- a/src/features/booth/components/MenuList.tsx
+++ b/src/features/booth/components/MenuList.tsx
@@ -3,13 +3,25 @@ import { useState } from 'react';
 import * as S from './MenuList.styles';
 import { MenuFrame } from '@/components/image-text-frame';
 import { useBooth } from '@/hooks/useBooth';
+import { useNavigate } from 'react-router-dom';
 const MENU_CATEGORY = ['메인 메뉴', '사이드 메뉴', '기타'];
 
 export default function MenuList({ id }: { id: number }) {
   const [activeTab, setActiveTab] = useState<string>('');
   const { booth, error } = useBooth(id);
+  const navigate = useNavigate();
 
-  if (error || !booth) return <div>메뉴 정보를 찾을 수 없습니다.</div>;
+  if (error || !booth) {
+    navigate('/error', {
+      state: {
+        mainText: '서버가 힘들어하고 있어요.',
+        subText: '멋사가 금방 고쳐올테니, 잠시 후에 다시 와주세요!',
+        showBackButton: true,
+        showHomeButton: true,
+      },
+    });
+    return null;
+  }
   return (
     <>
       <S.TabsContainer>

--- a/src/features/booth/components/MenuList.tsx
+++ b/src/features/booth/components/MenuList.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import * as S from './MenuList.styles';
 import { MenuFrame } from '@/components/image-text-frame';
 import { useBooth } from '@/hooks/useBooth';
-const MENU_CATEGORY = ['메인 메뉴', '사이드 메뉴', '음료'];
+const MENU_CATEGORY = ['메인 메뉴', '사이드 메뉴', '기타'];
 
 export default function MenuList({ id }: { id: number }) {
   const [activeTab, setActiveTab] = useState<string>('');
@@ -49,13 +49,13 @@ export default function MenuList({ id }: { id: number }) {
         </S.MenuFrame>
       )}
 
-      {activeTab === '' && booth.menu.sub.length > 0 && <S.HorizontalLine />}
+      {activeTab === '' && booth.menu.others.length > 0 && <S.HorizontalLine />}
 
-      {(activeTab === '' || activeTab === '음료') && (
+      {(activeTab === '' || activeTab === '기타') && (
         <S.MenuFrame>
-          <S.MenuItem>음료</S.MenuItem>
+          <S.MenuItem>기타</S.MenuItem>
           <S.MenuList>
-            {booth.menu.sub.map((menu) => (
+            {booth.menu.others.map((menu) => (
               <MenuFrame
                 menu={menu.name}
                 price={menu.price}

--- a/src/pages/booth/BoothDetail.tsx
+++ b/src/pages/booth/BoothDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { NavBar } from '@/components/nav-bar';
 import * as S from './BoothDetail.styles';
 import { BoothInfo, BoothLocation, MenuList } from '@/features/booth';
@@ -9,6 +9,7 @@ import { useFavorites } from '@/hooks/useFavorites';
 import { useBooth } from '@/hooks/useBooth';
 
 export default function BoothDetail() {
+  const navigate = useNavigate();
   const { id } = useParams();
   const location = useLocation();
   const fromRef = useRef(location.state?.from || '/booth');
@@ -20,12 +21,15 @@ export default function BoothDetail() {
   }, []);
 
   if (error || !booth) {
-    return (
-      <S.Container>
-        <NavBar isBack hideRight title="주점 정보" backPath={fromRef.current} />
-        <S.LoadingText>{error || '주점을 찾을 수 없습니다.'}</S.LoadingText>
-      </S.Container>
-    );
+    navigate('/error', {
+      state: {
+        mainText: '서버가 힘들어하고 있어요.',
+        subText: '멋사가 금방 고쳐올테니, 잠시 후에 다시 와주세요!',
+        showBackButton: true,
+        showHomeButton: true,
+      },
+    });
+    return null;
   }
 
   const isBoothFavorited = isFavorited(booth.id);

--- a/src/pages/booth/search/BoothSearch.styles.ts
+++ b/src/pages/booth/search/BoothSearch.styles.ts
@@ -124,6 +124,7 @@ export const EmptyText = styled.p`
   ${(props) => props.theme.fonts.body.medium500};
   color: ${(props) => props.theme.colors.grayScale.gy400};
   text-align: center;
+  margin-top: 110px;
 `;
 
 export const NoResultsState = styled.div`

--- a/src/services/boothService.ts
+++ b/src/services/boothService.ts
@@ -25,15 +25,15 @@ const transformMenusToBoothMenu = (menus: MenuApiResponse[]) => {
       price: `${m.price.toLocaleString()} 원`,
     }));
 
-  const sub = menus
-    .filter((m) => m.category === 'drink')
+  const others = menus
+    .filter((m) => m.category === 'others')
     .map((m) => ({
       name: m.name,
       describtion: m.description,
       price: `${m.price.toLocaleString()} 원`,
     }));
 
-  return { main, side, sub };
+  return { main, side, others };
 };
 
 const transformPubToBootn = async (pub: PubApiResponse): Promise<Booth> => {

--- a/src/types/booth.types.ts
+++ b/src/types/booth.types.ts
@@ -7,7 +7,7 @@ export interface BoothMenuItem {
 export interface BoothMenu {
   main: BoothMenuItem[];
   side: BoothMenuItem[];
-  sub: BoothMenuItem[];
+  others: BoothMenuItem[];
 }
 
 export interface Booth {
@@ -52,7 +52,7 @@ export interface PubDetailResponse {
 export interface MenuApiResponse {
   id: number;
   name: string;
-  category: 'main' | 'side' | 'drink';
+  category: 'main' | 'side' | 'others';
   description: string;
   price: number;
 }


### PR DESCRIPTION
## 구현 내용
- api 관련
   - 메뉴 api 필드명 변동사항 반영 (drink -> others)
- 디자인 QA 
   - empty text 문구 변경
   - empty text 블럭 margin 값 수정
 - error 관련
    - 주점 목록, 메뉴, 주점 정보 에러 페이지 리다이렉션 (error 2)
    
## 추가 해야하는 부분 
- [ ] 주점 찜 목록: 프론트엔드 에러 처리