### PR TITLE
fix: update exit handler to show confirmation modal only for specific steps

### DIFF
--- a/src/pages/main/notice/Notice.styles.ts
+++ b/src/pages/main/notice/Notice.styles.ts
@@ -15,6 +15,8 @@ export const Flex = styled.div`
 `;
 
 export const NoticeTabsWrapper = styled.div`
+  margin-bottom: 0.5rem;
+
   button[data-active='false'] {
     background-color: ${({ theme }) => theme.colors.grayScale.gy50} !important;
     border-color: transparent !important;


### PR DESCRIPTION
## 🔥 PR 제목  

fix: update exit handler to show confirmation modal only for specific steps

## 📌 작업 내용  

폴라로이드 화면에서 닫기 확인 모달을 `frame` & `develop` 에서만 보이도록 수정

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 테스트 완료  
- [x] 필요한 경우 문서를 업데이트했는지 확인  
- [x] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  