### PR TITLE
fix: 공지사항 닫힘 상태 하루 단위 초기화

### DIFF
--- a/src/pages/booth/BoothDetail.styles.ts
+++ b/src/pages/booth/BoothDetail.styles.ts
@@ -78,15 +78,3 @@ export const FavoriteButton = styled.button<{ $isFavorited: boolean }>`
   z-index: 10;
   transition: all 0.2s ease;
 `;
-
-export const LoadingText = styled.div`
-  display: flex;
-  height: 1.625rem;
-  padding: 0.0625rem 0.5rem;
-  justify-content: center;
-  align-items: center;
-  gap: 0.625rem;
-  margin-top: 320px;
-  ${(props) => props.theme.fonts.body.medium500};
-  color: ${(props) => props.theme.colors.primary.violet};
-`;

--- a/src/stores/useNotificationStore.ts
+++ b/src/stores/useNotificationStore.ts
@@ -3,9 +3,17 @@ import { persist } from 'zustand/middleware';
 import { CATEGORIES } from '@/constants/map/CATEGORIES';
 import { NOTIFICATION_STORAGE_KEY } from '@/constants/map/CategoryNotifications';
 
+// 오늘 날짜를 YYYY-MM-DD 형식으로 반환
+const getTodayString = (): string => {
+  return new Date().toISOString().split('T')[0];
+};
+
 interface NotificationState {
   // 닫힌 알림을 추적하는 Record (카테고리를 키로, true면 닫힘)
   closedNotifications: Partial<Record<CATEGORIES, boolean>>;
+
+  // 마지막 초기화 날짜 (YYYY-MM-DD 형식)
+  lastResetDate: string;
 
   // 알림 닫기 액션
   closeNotification: (category: CATEGORIES) => void;
@@ -18,6 +26,9 @@ interface NotificationState {
 
   // 알림이 닫혔는지 확인하는 함수
   isNotificationClosed: (category: CATEGORIES) => boolean;
+
+  // 하루가 지났는지 확인하고 필요시 초기화하는 함수
+  checkAndResetDaily: () => void;
 }
 
 // 초기 상태를 생성하는 함수
@@ -32,14 +43,29 @@ export const useNotificationStore = create<NotificationState>()(
     (set, get) => ({
       // 초기 상태는 비어있는 객체 (모든 알림이 열려있음)
       closedNotifications: createInitialState(),
+      lastResetDate: getTodayString(),
 
-      closeNotification: (category) =>
+      checkAndResetDaily: () => {
+        const today = getTodayString();
+        const { lastResetDate } = get();
+
+        if (lastResetDate !== today) {
+          set({
+            closedNotifications: {},
+            lastResetDate: today,
+          });
+        }
+      },
+
+      closeNotification: (category) => {
+        get().checkAndResetDaily();
         set((state) => ({
           closedNotifications: {
             ...state.closedNotifications,
             [category]: true,
           },
-        })),
+        }));
+      },
 
       resetNotification: (category) =>
         set((state) => {
@@ -48,9 +74,13 @@ export const useNotificationStore = create<NotificationState>()(
           return { closedNotifications: updated };
         }),
 
-      resetAllNotifications: () => set({ closedNotifications: {} }),
+      resetAllNotifications: () =>
+        set({ closedNotifications: {}, lastResetDate: getTodayString() }),
 
-      isNotificationClosed: (category) => !!get().closedNotifications[category],
+      isNotificationClosed: (category) => {
+        get().checkAndResetDaily();
+        return !!get().closedNotifications[category];
+      },
     }),
     {
       name: NOTIFICATION_STORAGE_KEY, // 로컬 스토리지 키


### PR DESCRIPTION
## 구현 내용
- 불필요한 Loading Text style 관련 코드 제거
- 공지 사항 닫힘 상태 하루 단위 초기화 기능 추가 (src/stores/useNotificationStore.ts)

## 코드 설명
- 날짜 추적 기능: lastResetDate 필드로 마지막 초기화 날짜 저장
- 하루 체크 함수: checkAndResetDaily() - 하루가 지나면 자동으로 모든 알림 초기화
- 체크 자동화: closeNotification()과 isNotificationClosed() 호출 시마다 하루 체크
- 폴라로이드 로직과 다르게 구현 (알림 확인, 닫기 활동마다 체크 / 기존 수동 연월일 조합을 toISOString().split('T')[0] 사용으로 대체)

 