### PR TITLE
fix: 주점 상세 페이지 style 값 수정 및 찜하기 버튼 컴포넌트 분리

### DIFF
--- a/src/components/favorite-button/FavoriteButton.styles.ts
+++ b/src/components/favorite-button/FavoriteButton.styles.ts
@@ -35,7 +35,7 @@ export const FavoriteButton = styled.button<{
       case 'large':
         return `
           width: 3.375rem;
-          height: 4.4rem;
+          height: 4.5rem;
           flex-direction: column;
           gap: 0.4375rem;
           font-size: 0.75rem;

--- a/src/components/favorite-button/FavoriteButton.styles.ts
+++ b/src/components/favorite-button/FavoriteButton.styles.ts
@@ -34,13 +34,12 @@ export const FavoriteButton = styled.button<{
     switch ($variant) {
       case 'large':
         return `
-          width: 54px;
-          height: 72px;
+          width: 3.375rem;
+          height: 4.4rem;
           flex-direction: column;
-          gap: 7px;
-          font-size: 12px;
-          top: 10.5rem;
-          right: 20px;
+          gap: 0.4375rem;
+          font-size: 0.75rem;
+          top: 1.1rem;
         `;
       case 'default':
       default:

--- a/src/components/favorite-button/FavoriteButton.styles.ts
+++ b/src/components/favorite-button/FavoriteButton.styles.ts
@@ -1,0 +1,75 @@
+import styled from 'styled-components';
+
+export const FavoriteButton = styled.button<{
+  $isFavorited: boolean;
+  $variant: 'default' | 'large';
+  $position: 'relative' | 'absolute';
+  $mode?: 'favorite' | 'delete';
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: ${({ $isFavorited, $mode, theme }) => {
+    if ($mode === 'delete') return 'none';
+    return $isFavorited ? 'none' : `1px solid ${theme.colors.primary.violet}`;
+  }};
+  background: ${({ $isFavorited, $mode, $variant, theme }) => {
+    if ($mode === 'delete') return 'transparent';
+    if ($variant === 'large') {
+      return $isFavorited ? theme.colors.primary.violet : 'rgba(255, 255, 255, 0.9)';
+    }
+    return $isFavorited ? theme.colors.primary.violet : 'none';
+  }};
+  color: ${({ $isFavorited, $mode, theme }) => {
+    if ($mode === 'delete') return theme.colors.grayScale.gy400;
+    return $isFavorited ? '#ffffff' : theme.colors.primary.violet;
+  }};
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  z-index: 10;
+  position: ${({ $position }) => $position};
+
+  ${({ $variant }) => {
+    switch ($variant) {
+      case 'large':
+        return `
+          width: 54px;
+          height: 72px;
+          flex-direction: column;
+          gap: 7px;
+          font-size: 12px;
+          top: 10.5rem;
+          right: 20px;
+        `;
+      case 'default':
+      default:
+        return `
+          flex-shrink: 0;
+          width: 3.375rem;
+          height: 4.5rem;
+          flex-direction: column;
+          gap: 0.4375rem;
+          font-size: 0.75rem;
+        `;
+    }
+  }}
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  &:hover:not(:disabled) {
+    transform: scale(1.05);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.95);
+  }
+`;
+
+export const ButtonText = styled.span<{ $variant: 'default' | 'large' }>`
+  ${(props) => props.theme.fonts.body.xsmall500};
+  ${({ $variant }) => $variant === 'large' && 'text-align: center;'}
+`;

--- a/src/components/favorite-button/FavoriteButton.styles.ts
+++ b/src/components/favorite-button/FavoriteButton.styles.ts
@@ -39,7 +39,7 @@ export const FavoriteButton = styled.button<{
           flex-direction: column;
           gap: 0.4375rem;
           font-size: 0.75rem;
-          top: 1.1rem;
+          top: 0rem;
         `;
       case 'default':
       default:

--- a/src/components/favorite-button/FavoriteButton.tsx
+++ b/src/components/favorite-button/FavoriteButton.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import * as S from './FavoriteButton.styles';
+import { FavoriteButtonProps } from './FavoriteButton.types';
+import FavoriteOn from '@/assets/icons/favorite-on.svg?react';
+import FavoriteOff from '@/assets/icons/favorite-off.svg?react';
+import TrashIcon from '@/assets/icons/trash.svg?react';
+
+const FavoriteButton: React.FC<FavoriteButtonProps> = ({
+  id,
+  isFavorited,
+  onClick,
+  variant = 'default',
+  position = 'relative',
+  mode = 'favorite',
+  className,
+  disabled = false,
+}) => {
+  const handleClick = (event: React.MouseEvent) => {
+    if (disabled) return;
+    onClick(id, event);
+  };
+
+  const getIcon = () => {
+    if (mode === 'delete') return <TrashIcon />;
+    return isFavorited ? <FavoriteOn /> : <FavoriteOff />;
+  };
+
+  const getText = () => {
+    if (mode === 'delete') return null;
+    return isFavorited ? '찜 완료' : '찜하기';
+  };
+
+  const getAriaLabel = () => {
+    if (mode === 'delete') return '삭제하기';
+    return isFavorited ? '찜 완료' : '찜하기';
+  };
+
+  return (
+    <S.FavoriteButton
+      onClick={handleClick}
+      $isFavorited={isFavorited}
+      $variant={variant}
+      $position={position}
+      $mode={mode}
+      className={className}
+      disabled={disabled}
+      aria-label={getAriaLabel()}
+    >
+      {getIcon()}
+      {getText() && <S.ButtonText $variant={variant}>{getText()}</S.ButtonText>}
+    </S.FavoriteButton>
+  );
+};
+
+export default FavoriteButton;

--- a/src/components/favorite-button/FavoriteButton.types.ts
+++ b/src/components/favorite-button/FavoriteButton.types.ts
@@ -1,0 +1,10 @@
+export interface FavoriteButtonProps {
+  id: number;
+  isFavorited: boolean;
+  onClick: (id: number, event: React.MouseEvent) => void;
+  variant?: 'default' | 'large';
+  position?: 'relative' | 'absolute';
+  mode?: 'favorite' | 'delete';
+  className?: string;
+  disabled?: boolean;
+}

--- a/src/components/favorite-button/index.ts
+++ b/src/components/favorite-button/index.ts
@@ -1,0 +1,2 @@
+export { default as FavoriteButton } from './FavoriteButton';
+export * from './FavoriteButton.types';

--- a/src/components/image-text-frame/ImageTextFrame.styles.ts
+++ b/src/components/image-text-frame/ImageTextFrame.styles.ts
@@ -185,6 +185,7 @@ export const MenuTextWrap = styled.div`
   flex-grow: 1;
   min-width: 0;
   gap: 0.125rem;
+  padding: 0 20;
 `;
 
 export const MenuDescription = styled.p`
@@ -204,6 +205,7 @@ export const menuTitle = styled.p`
   white-space: nowrap;
   min-width: 0;
   flex: 0 1 auto;
+  margin-top: 12px;
 `;
 
 export const Price = styled.p`

--- a/src/features/booth/components/BoothInfo.styles.ts
+++ b/src/features/booth/components/BoothInfo.styles.ts
@@ -8,7 +8,7 @@ export const Container = styled.div`
 
 export const ImageBtnFrame = styled.div`
   width: 100%;
-  height: 6.25rem;
+  height: auto;
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
@@ -17,9 +17,10 @@ export const ImageBtnFrame = styled.div`
 export const Image = styled.img`
   width: 6.25rem;
   height: 6.25rem;
-  background: ${(props) => props.theme.colors.grayScale.gy100};
-  border-radius: 0.75rem;
-  border: 0.5px solid ${(props) => props.theme.colors.grayScale.gy100};
+  background: ${(props) => props.theme.colors.grayScale.gy400};
+  border-radius: 12px;
+  border: 1px solid ${(props) => props.theme.colors.grayScale.gy100};
+  margin-top: 1.2rem;
 `;
 
 export const TextSection = styled.div`

--- a/src/features/booth/components/BoothInfo.styles.ts
+++ b/src/features/booth/components/BoothInfo.styles.ts
@@ -4,6 +4,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  margin-bottom: 0;
 `;
 
 export const ImageBtnFrame = styled.div`
@@ -42,11 +43,6 @@ export const Text = styled.p`
 export const BoothName = styled(Text)`
   ${(props) => props.theme.fonts.header.h2};
   color: ${(props) => props.theme.colors.grayScale.black};
-`;
-
-export const VerticalLine = styled.div`
-  width: 0.0625rem;
-  background: ${(props) => props.theme.colors.grayScale.gy100};
 `;
 
 export const TakeOut = styled.div`

--- a/src/features/booth/components/BoothInfo.tsx
+++ b/src/features/booth/components/BoothInfo.tsx
@@ -41,8 +41,6 @@ export default function BoothInfo({ id }: { id: number }) {
       </S.ImageBtnFrame>
       <S.TextSection>
         <S.TextFrame>
-          <S.Text>{booth.type}</S.Text>
-          <S.VerticalLine />
           <S.Text>{booth.affiliation}</S.Text>
         </S.TextFrame>
         <S.BoothName

--- a/src/features/booth/components/BoothInfo.tsx
+++ b/src/features/booth/components/BoothInfo.tsx
@@ -1,6 +1,8 @@
 import * as S from './BoothInfo.styles';
+import { FavoriteButton } from '@/components/favorite-button';
 import { newlineToBr } from '@/utils/newlineToBr';
 import { useBooth } from '@/hooks/useBooth';
+import { useFavorites } from '@/hooks/useFavorites';
 import { useNavigate } from 'react-router-dom';
 import { OPERATING_HOURS } from '@/constants/booth/operating-hours';
 import PubBeerIcon from '@/assets/icons/pub_beer.svg?react';
@@ -8,6 +10,7 @@ import TimeIcon from '@/assets/icons/time_pub.svg?react';
 
 export default function BoothInfo({ id }: { id: number }) {
   const { booth, error } = useBooth(id);
+  const { handleToggleFavorite, isFavorited } = useFavorites();
   const navigate = useNavigate();
 
   if (error || !booth) {
@@ -21,10 +24,20 @@ export default function BoothInfo({ id }: { id: number }) {
     });
     return null;
   }
+
+  const isBoothFavorited = isFavorited(booth.id);
+
   return (
     <S.Container>
       <S.ImageBtnFrame>
         <S.Image src={booth.profileImage} />
+        <FavoriteButton
+          id={booth.id}
+          isFavorited={isBoothFavorited}
+          onClick={handleToggleFavorite}
+          variant="large"
+          position="relative"
+        />
       </S.ImageBtnFrame>
       <S.TextSection>
         <S.TextFrame>

--- a/src/features/booth/components/BoothList.styles.ts
+++ b/src/features/booth/components/BoothList.styles.ts
@@ -49,37 +49,6 @@ export const BoothItemWrapper = styled.div`
   gap: 0.75rem;
 `;
 
-export const FavoriteButton = styled.button<{ $isFavorited: boolean; $isTrashMode?: boolean }>`
-  flex-shrink: 0;
-  gap: 0.4375rem;
-  border: ${({ $isFavorited, $isTrashMode, theme }) => {
-    if ($isTrashMode) return 'none';
-    return $isFavorited ? 'none' : `1px solid ${theme.colors.primary.violet}`;
-  }};
-  background: ${({ $isFavorited, $isTrashMode, theme }) => {
-    if ($isTrashMode) return 'transparent';
-    return $isFavorited ? theme.colors.primary.violet : 'none';
-  }};
-  border-radius: 0.75rem;
-  width: 3.375rem;
-  height: 4.5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.75rem;
-  color: ${({ $isFavorited, $isTrashMode, theme }) => {
-    if ($isTrashMode) return theme.colors.grayScale.gy400;
-    return $isFavorited ? '#ffffff' : theme.colors.primary.violet;
-  }};
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:active {
-    transform: scale(0.95);
-  }
-`;
-
 export const TabContainer = styled.div<{ width?: string }>`
   position: relative;
   display: flex;

--- a/src/features/booth/components/BoothList.tsx
+++ b/src/features/booth/components/BoothList.tsx
@@ -1,15 +1,12 @@
 import * as S from './BoothList.styles';
 import { ImageTextFrameWithOrganization } from '@/components/image-text-frame';
 import { Notification } from '@/components/notification';
+import { FavoriteButton } from '@/components/favorite-button';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Fragment } from 'react/jsx-runtime';
 import { useState } from 'react';
 import { useBooths } from '@/hooks/useBooth';
 import { useBoothNotificationStore } from '@/stores/useBoothNotificationStore';
-
-import FavoriteOn from 'src/assets/icons/favorite-on.svg?react';
-import FavoriteOff from 'src/assets/icons/favorite-off.svg?react';
-import TrashIcon from 'src/assets/icons/trash.svg?react';
 
 interface BoothListProps {
   showFavoritesOnly?: boolean;
@@ -117,20 +114,12 @@ export default function BoothList({ showFavoritesOnly = false, hideTabs = false 
                         })
                       }
                     />
-                    <S.FavoriteButton
-                      onClick={(e) => handleToggleFavorite(booth.id, e)}
-                      $isFavorited={isFavorited}
-                      $isTrashMode={showFavoritesOnly}
-                    >
-                      {showFavoritesOnly ? (
-                        <TrashIcon />
-                      ) : isFavorited ? (
-                        <FavoriteOn />
-                      ) : (
-                        <FavoriteOff />
-                      )}
-                      {showFavoritesOnly ? null : isFavorited ? '찜 완료' : '찜하기'}
-                    </S.FavoriteButton>
+                    <FavoriteButton
+                      id={booth.id}
+                      isFavorited={isFavorited}
+                      onClick={handleToggleFavorite}
+                      mode={showFavoritesOnly ? 'delete' : 'favorite'}
+                    />
                   </S.BoothItemWrapper>
                   {!hideTabs && <S.HorizontalLine />}
                 </Fragment>

--- a/src/features/booth/components/BoothLocation.styles.ts
+++ b/src/features/booth/components/BoothLocation.styles.ts
@@ -39,7 +39,7 @@ export const Button = styled.button`
   position: absolute;
   right: 0.75rem;
   bottom: 0.75rem;
-  z-index: 999;
+  z-index: 99;
 `;
 
 export const ButtonText = styled.p`

--- a/src/features/booth/components/BoothLocation.styles.ts
+++ b/src/features/booth/components/BoothLocation.styles.ts
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 export const Container = styled.section`
-  padding: 2.75rem 0rem 0rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/src/features/booth/components/MenuList.styles.ts
+++ b/src/features/booth/components/MenuList.styles.ts
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 export const MenuList = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
 `;
 
 export const MenuFrame = styled.div`
@@ -11,8 +10,6 @@ export const MenuFrame = styled.div`
   flex-direction: column;
   width: 100%;
   gap: 0.375rem;
-  margin-bottom: 1rem;
-  margin-top: 20px;
 `;
 
 export const MenuItem = styled.div`
@@ -20,7 +17,6 @@ export const MenuItem = styled.div`
 
   display: flex;
   flex-direction: column;
-  gap: 1rem;
 `;
 
 export const MenuCategory = styled.p`
@@ -29,12 +25,13 @@ export const MenuCategory = styled.p`
 `;
 
 export const TabsContainer = styled.div`
-  margin-bottom: 1.5rem;
+  margin-top: 6px;
+  margin-bottom: 36px;
 `;
 
 export const HorizontalLine = styled.div`
   width: 100%;
   height: 1px;
   background-color: ${(props) => props.theme.colors.grayScale.gy300};
-  margin: 1.5rem 0;
+  margin: 36px 0;
 `;

--- a/src/pages/booth/BoothDetail.styles.ts
+++ b/src/pages/booth/BoothDetail.styles.ts
@@ -9,7 +9,6 @@ export const BackgroundImg = styled.img`
 `;
 
 export const Section = styled.div`
-  padding: 0rem 0rem 1.75rem;
   width: 20.9375rem;
   display: flex;
   flex-direction: column;
@@ -18,10 +17,8 @@ export const Section = styled.div`
 
 export const BorderSection = styled.div`
   width: 20.9375rem;
-  padding: 0rem 0rem 2.75rem;
   display: flex;
   flex-direction: column;
-  margin-top: 25px;
 `;
 
 export const BottomPadding = styled.div`
@@ -50,7 +47,7 @@ export const TakeOut = styled.div`
 export const HorizontalLine = styled.div`
   height: 0.5rem;
   width: 100%;
-  margin-top: 36px;
-  margin-bottom: 36px;
+  margin-top: 40px;
+  margin-bottom: 40px;
   background-color: ${(props) => props.theme.colors.grayScale.gy200};
 `;

--- a/src/pages/booth/BoothDetail.styles.ts
+++ b/src/pages/booth/BoothDetail.styles.ts
@@ -54,26 +54,3 @@ export const HorizontalLine = styled.div`
   margin-bottom: 36px;
   background-color: ${(props) => props.theme.colors.grayScale.gy200};
 `;
-
-export const FavoriteButton = styled.button<{ $isFavorited: boolean }>`
-  position: absolute;
-  top: 10.5rem;
-  right: 20px;
-  gap: 7px;
-  border: ${({ $isFavorited, theme }) =>
-    $isFavorited ? 'none' : `1px solid ${theme.colors.primary.violet}`};
-  background: ${({ $isFavorited, theme }) =>
-    $isFavorited ? theme.colors.primary.violet : 'rgba(255, 255, 255, 0.9)'};
-  border-radius: 12px;
-  width: 54px;
-  height: 72px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: 12px;
-  color: ${({ $isFavorited, theme }) => ($isFavorited ? '#ffffff' : theme.colors.primary.violet)};
-  cursor: pointer;
-  z-index: 10;
-  transition: all 0.2s ease;
-`;

--- a/src/pages/booth/BoothDetail.styles.ts
+++ b/src/pages/booth/BoothDetail.styles.ts
@@ -34,7 +34,6 @@ export const Container = styled.div`
   align-items: center;
   position: relative;
   padding-top: 3.875rem;
-  margin-left: -15px;
 `;
 
 export const TakeOut = styled.div`

--- a/src/pages/booth/BoothDetail.tsx
+++ b/src/pages/booth/BoothDetail.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { NavBar } from '@/components/nav-bar';
-import { FavoriteButton } from '@/components/favorite-button';
 import * as S from './BoothDetail.styles';
 import { BoothInfo, BoothLocation, MenuList } from '@/features/booth';
-import { useFavorites } from '@/hooks/useFavorites';
 import { useBooth } from '@/hooks/useBooth';
 
 export default function BoothDetail() {
@@ -13,7 +11,6 @@ export default function BoothDetail() {
   const location = useLocation();
   const fromRef = useRef(location.state?.from || '/booth');
   const { booth, error } = useBooth(Number(id) || 0);
-  const { handleToggleFavorite, isFavorited } = useFavorites();
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -31,19 +28,10 @@ export default function BoothDetail() {
     return null;
   }
 
-  const isBoothFavorited = isFavorited(booth.id);
-
   return (
     <S.Container>
       <NavBar isBack hideRight title="주점 정보" backPath={fromRef.current} />
       <S.BackgroundImg src={booth.posterImage} />
-      <FavoriteButton
-        id={booth.id}
-        isFavorited={isBoothFavorited}
-        onClick={handleToggleFavorite}
-        variant="large"
-        position="absolute"
-      />
       <S.Section style={{ marginTop: '-2rem' }}>
         <BoothInfo id={booth.id} />
       </S.Section>

--- a/src/pages/booth/BoothDetail.tsx
+++ b/src/pages/booth/BoothDetail.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useRef } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { NavBar } from '@/components/nav-bar';
+import { FavoriteButton } from '@/components/favorite-button';
 import * as S from './BoothDetail.styles';
 import { BoothInfo, BoothLocation, MenuList } from '@/features/booth';
-import FavoriteOn from 'src/assets/icons/favorite-on.svg?react';
-import FavoriteOff from 'src/assets/icons/favorite-off.svg?react';
 import { useFavorites } from '@/hooks/useFavorites';
 import { useBooth } from '@/hooks/useBooth';
 
@@ -38,14 +37,13 @@ export default function BoothDetail() {
     <S.Container>
       <NavBar isBack hideRight title="주점 정보" backPath={fromRef.current} />
       <S.BackgroundImg src={booth.posterImage} />
-      <S.FavoriteButton
-        onClick={(e) => handleToggleFavorite(booth.id, e)}
-        $isFavorited={isBoothFavorited}
-        aria-label={isBoothFavorited ? '찜 완료' : '찜하기'}
-      >
-        {isBoothFavorited ? <FavoriteOn /> : <FavoriteOff />}
-        {isBoothFavorited ? '찜 완료' : '찜하기'}
-      </S.FavoriteButton>
+      <FavoriteButton
+        id={booth.id}
+        isFavorited={isBoothFavorited}
+        onClick={handleToggleFavorite}
+        variant="large"
+        position="absolute"
+      />
       <S.Section style={{ marginTop: '-2rem' }}>
         <BoothInfo id={booth.id} />
       </S.Section>

--- a/src/services/boothService.ts
+++ b/src/services/boothService.ts
@@ -43,7 +43,6 @@ const transformPubToBootn = async (pub: PubApiResponse): Promise<Booth> => {
   return {
     id: pub.id,
     locate: pub.location,
-    type: pub.type,
     affiliation: pub.affiliation,
     pubName: pub.name,
     takeout: pub.takeout,

--- a/src/types/booth.types.ts
+++ b/src/types/booth.types.ts
@@ -15,7 +15,6 @@ export interface Booth {
   locate: string;
   latitude: number;
   longitude: number;
-  type: string;
   affiliation: string;
   pubName: string;
   menu: BoothMenu;
@@ -29,7 +28,6 @@ export interface PubApiResponse {
   location: string;
   latitude: number;
   longitude: number;
-  type: string;
   affiliation: string;
   name: string;
   takeout: boolean;


### PR DESCRIPTION
## 구현 내용
- 찜하기 버튼 컴포넌트 분리 (재사용 고려 코드 중복 해결)
- 찜하기 버튼 리팩토링
- 기존 찜하기 버튼 관련 스타일, ts 함수 제거
- 주점 상세 페이지 내 이미지 값 위치, 테두리 수정
- 디자인 QA 반영하여 전체 margin 및 padding 값 수정