### PR TITLE
refactor: 바텀시트 높이 수정

### DIFF
--- a/src/constants/map/MapData.ts
+++ b/src/constants/map/MapData.ts
@@ -57,6 +57,7 @@ export interface MapDataItem extends ImageTextFrameWithTimeProps {
   lat?: number; // 위도
   lng?: number; // 경도
   closeDay?: DAYS[];
+  canPickup?: boolean; // 포장가능 여부
 }
 
 // 전체 맵 데이터의 타입 정의

--- a/src/features/map/bottomsheet/BottomSheet.styles.ts
+++ b/src/features/map/bottomsheet/BottomSheet.styles.ts
@@ -8,7 +8,7 @@ export const BottomSheetMotionDiv = styled(motion.div)`
   display: flex;
   flex-direction: column;
   position: fixed;
-  top: calc(100% - 19.875rem); /* 뷰포트 하단 기준 몇 px */
+  top: calc(100% - 13.875rem); /* 뷰포트 하단 기준 몇 px */
   left: 0;
   right: 0;
   margin: 0;

--- a/src/features/map/bottomsheet/MapItemCard.styles.ts
+++ b/src/features/map/bottomsheet/MapItemCard.styles.ts
@@ -11,18 +11,6 @@ export const MapItemCardContainer = styled.div`
   overflow: hidden;
 `;
 
-export const BoothCardContainer = styled.div`
-  display: flex;
-  width: 20.9375rem; /* 335px */
-  align-items: center;
-  gap: 0.75rem; /* 12px */
-  cursor: pointer;
-
-  &:active {
-    background-color: ${(props) => props.theme.colors.grayScale.gy50};
-  }
-`;
-
 export const ItemImage = styled.img`
   width: 4.5rem; /* 72px */
   height: 4.5rem; /* 72px */
@@ -63,89 +51,24 @@ export const ItemCategory = styled.span`
   margin: 0.1563rem 0 0;
 `;
 
-// 주점용 스타일 컴포넌트들 (ImageTextFrameWithTime에서 복사)
-export const BoothContentsWrap = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  text-align: left;
-  flex: 1;
-  flex-grow: 1;
-  min-width: 0;
-  gap: 0.25rem;
-`;
-
-export const BoothTitleWrap = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 0.25rem;
-  width: 100%;
-  overflow: hidden;
-  min-width: 0;
-`;
-
-export const BoothTitle = styled.p`
-  ${(props) => props.theme.fonts.header.h4}
-  color: ${(props) => props.theme.colors.grayScale.black};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-  flex: 0 1 auto;
-`;
-
-export const BoothTitleDivider = styled.div`
-  width: 0.063rem;
-  height: 1rem;
-  background-color: ${(props) => props.theme.colors.grayScale.gy100};
-  flex-shrink: 0;
-  margin: 0 0.125rem;
-`;
-
-export const BoothSubTitle = styled.span`
-  ${(props) => props.theme.fonts.body.medium400}
-  color: ${(props) => props.theme.colors.grayScale.gy200};
-  white-space: nowrap;
-  flex: 0 0 auto;
-`;
-
-export const BoothContentsFooter = styled.div`
+export const BoothItemWrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  overflow: hidden;
+  gap: 0.75rem;
 `;
 
-export const BoothTimeWrap = styled.div`
+export const Pickup = styled.div`
   display: flex;
-  flex-direction: row;
+  padding: 0.125rem 0.375rem; /* 2px 6px */
   align-items: center;
-  gap: 0.25rem;
-`;
-
-export const BoothTime = styled.p`
-  ${(props) => props.theme.fonts.body.small400}
-  color: ${(props) => props.theme.colors.grayScale.black};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 10rem;
-`;
-
-export const BoothLinkToDetail = styled.div`
-  display: flex;
-  width: 3.75rem;
-  height: 1.5rem;
-  justify-content: center;
-  align-items: center;
+  gap: 0.125rem; /* 2px */
+  border-radius: 0.75rem; /* 12px */
+  background: ${(props) => props.theme.colors.primary.violet}20; /* rgba(126, 65, 154, 0.20) */
+  margin-top: 0.25rem;
+  ${(props) => props.theme.fonts.body.xsmall500};
+  color: ${(props) => props.theme.colors.primary.violet};
   text-align: center;
-  gap: 0.625rem;
-  background-color: ${(props) => props.theme.colors.secondary.pk100};
-  ${(props) => props.theme.fonts.body.xsmall400};
-  border-radius: 0.375rem;
-  color: ${(props) => props.theme.colors.grayScale.white};
-  flex-shrink: 0;
 `;

--- a/src/features/map/bottomsheet/MapItemCard.tsx
+++ b/src/features/map/bottomsheet/MapItemCard.tsx
@@ -1,7 +1,9 @@
 import { MapDataItem } from '@/constants/map/MapData';
 import * as S from './MapItemCard.styles';
-import TimeIcon from '@/assets/icons/clock.svg?react';
+import { FavoriteButton } from '@/components/favorite-button';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import PubBeerIcon from '@/assets/icons/pub_beer.svg?react';
 
 interface MapItemCardProps {
   item: MapDataItem;
@@ -12,49 +14,64 @@ interface MapItemCardProps {
 export function MapItemCard({ item, onItemClick, category }: MapItemCardProps) {
   const navigate = useNavigate();
 
-  const handleDetailClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // 이벤트 버블링 중지
-    if (item.path) {
-      navigate(item.path);
-    }
+  // 찜하기 기능 상태 관리 (localStorage)
+  const [favorites, setFavorites] = useState<number[]>(() => {
+    const saved = localStorage.getItem('booth-favorites');
+    return saved ? JSON.parse(saved) : [];
+  });
+
+  const handleToggleFavorite = (boothId: number, event: React.MouseEvent) => {
+    event.stopPropagation();
+
+    setFavorites((prev) => {
+      const newFavorites = prev.includes(boothId)
+        ? prev.filter((id) => id !== boothId)
+        : [...prev, boothId];
+
+      localStorage.setItem('booth-favorites', JSON.stringify(newFavorites));
+      return newFavorites;
+    });
   };
 
-  // 주점 카테고리인 경우 booth 스타일 사용 (border 없이)
-  if (category === '주점') {
+  // 주점 카테고리인 경우 찜하기 버튼과 함께 표시
+  if (category === '주점' && item.id) {
+    const isFavorited = favorites.includes(item.id);
+
     return (
-      <S.BoothCardContainer
-        onClick={() => {
-          if (onItemClick && item.lat && item.lng) {
-            onItemClick(item);
-          }
-        }}
-      >
-        <S.ItemImage src={item.image} alt={item.title} />
-        <S.BoothContentsWrap>
-          <S.BoothTitleWrap>
-            <S.BoothTitle>{item.title}</S.BoothTitle>
-            {item.subtitle && (
-              <>
-                <S.BoothTitleDivider />
-                <S.BoothSubTitle>{item.subtitle}</S.BoothSubTitle>
-              </>
+      <S.BoothItemWrapper>
+        <S.MapItemCardContainer
+          onClick={() => {
+            // 주점 카테고리인 경우 상세페이지로 이동
+            if (category === '주점' && item.id) {
+              navigate(`/booth/${item.id}`);
+            } else if (onItemClick && item.lat && item.lng) {
+              onItemClick(item);
+            }
+          }}
+        >
+          <S.ItemImage src={item.image} alt={item.title} />
+          <S.ItemContent>
+            <S.ItemTitle>{item.title}</S.ItemTitle>
+            <S.ItemCategory>{category}</S.ItemCategory>
+            {item.canPickup && (
+              <S.Pickup>
+                <PubBeerIcon width="0.75rem" height="0.75rem" />
+                포장가능
+              </S.Pickup>
             )}
-          </S.BoothTitleWrap>
-          <S.BoothContentsFooter>
-            <S.BoothTimeWrap>
-              <TimeIcon width="1.25rem" height="1.25rem" fill="#17171B" />
-              <S.BoothTime>{item.time}</S.BoothTime>
-            </S.BoothTimeWrap>
-            {item.path && (
-              <S.BoothLinkToDetail onClick={handleDetailClick}>상세보기</S.BoothLinkToDetail>
-            )}
-          </S.BoothContentsFooter>
-        </S.BoothContentsWrap>
-      </S.BoothCardContainer>
+          </S.ItemContent>
+        </S.MapItemCardContainer>
+        <FavoriteButton
+          id={item.id}
+          isFavorited={isFavorited}
+          onClick={handleToggleFavorite}
+          mode="favorite"
+        />
+      </S.BoothItemWrapper>
     );
   }
 
-  // 주점이 아닌 경우 새로운 디자인 사용
+  // 주점이 아닌 경우 기본 디자인 사용
   return (
     <S.MapItemCardContainer
       onClick={() => {

--- a/src/features/performance/NewCarousel.tsx
+++ b/src/features/performance/NewCarousel.tsx
@@ -13,6 +13,7 @@ export default function NewCarousel({ data, onIndexChange, onArtistClick }: NewC
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const [textFade, setTextFade] = useState<'in' | 'out'>('in');
   const isSwipingRef = useRef(false);
+  const isInitializedRef = useRef(false);
   const sliderRef = useRef<Slider>(null);
 
   // 텍스트 fade 처리
@@ -37,6 +38,10 @@ export default function NewCarousel({ data, onIndexChange, onArtistClick }: NewC
     if (sliderRef.current && data.length > 0) {
       sliderRef.current.slickGoTo(0);
       setCurrentIndex(0);
+      // 초기화 완료 후 짧은 지연을 두고 클릭 허용
+      setTimeout(() => {
+        isInitializedRef.current = true;
+      }, 200);
     }
   }, [data]);
 
@@ -103,7 +108,7 @@ export default function NewCarousel({ data, onIndexChange, onArtistClick }: NewC
                             src={singer.backgroundUrl}
                             alt={singer.singer}
                             onClick={() => {
-                              if (isSwipingRef.current) return;
+                              if (isSwipingRef.current || !isInitializedRef.current) return;
                               onArtistClick?.(singer);
                             }}
                             style={{ cursor: 'pointer' }}
@@ -117,7 +122,7 @@ export default function NewCarousel({ data, onIndexChange, onArtistClick }: NewC
                             src={singer.backgroundUrl}
                             alt={singer.singer}
                             onClick={() => {
-                              if (isSwipingRef.current) return;
+                              if (isSwipingRef.current || !isInitializedRef.current) return;
                               onArtistClick?.(singer);
                             }}
                             style={{ cursor: 'pointer' }}

--- a/src/pages/map/MapPage.styles.ts
+++ b/src/pages/map/MapPage.styles.ts
@@ -18,7 +18,7 @@ export const MapWrapper = styled.div<{ $isBottomSheetOpen?: boolean }>`
   left: 0;
   width: 100%;
   height: ${(props) =>
-    props.$isBottomSheetOpen ? 'calc(100% - 260px)' : '100%'}; /* 260px = 16.25rem */
+    props.$isBottomSheetOpen ? 'calc(100% - 154px)' : '100%'}; /* 260px = 16.25rem */
 
   z-index: ${Z_INDEX.MAP};
   transition: height 0.3s ease-in-out;
@@ -71,7 +71,7 @@ export const CategoryTabsContainer = styled.div<{ $isFromSearch?: boolean }>`
 
 export const ReCenterButton = styled.div<{ $isBottomSheetOpen?: boolean }>`
   position: fixed;
-  bottom: ${(props) => (props.$isBottomSheetOpen ? '21.188rem' : '8rem')};
+  bottom: ${(props) => (props.$isBottomSheetOpen ? '15.188rem' : '8rem')};
   left: 1.25rem;
   width: 4rem;
   height: 4rem;

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -5,7 +5,6 @@ import { NavBar } from '@/components/nav-bar';
 import { Tabs } from '@/components/tabs';
 import SearchBar from '@/components/search-bar/SearchBar';
 import DaySelectorModal from '@/components/day-selector-modal/DaySelectorModal';
-import { BoothList } from '@/features/booth';
 import { DAYS, CATEGORIES } from '@/constants/map';
 import { FESTIVAL_START_DATE, FESTIVAL_TOTAL_DAYS } from '@/constants/festival/dates';
 import { getCurrentFestivalDay } from '@/utils/dateUtils';
@@ -15,6 +14,7 @@ import ReCenterButtonIcon from '@/assets/icons/re-center.svg?react';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { MapData, MapDataItem } from '@/constants/map/MapData';
 import { useMarkerStore } from '@/stores/useMarkerStore';
+import { useBooths } from '@/hooks/useBooth';
 
 export default function Map() {
   // URL에서 itemId 파라미터 가져오기
@@ -45,6 +45,9 @@ export default function Map() {
 
   // Marker store 사용
   const { fetchMarkers, markers, loading: isApiLoading, isInitialized } = useMarkerStore();
+
+  // Booth API 사용
+  const { booths } = useBooths();
 
   // 모달 상태
   const [isDayModalOpen, setIsDayModalOpen] = useState<boolean>(false);
@@ -110,17 +113,39 @@ export default function Map() {
 
   // 통합된 맵 데이터 (모든 카테고리를 API 데이터로 사용)
   const integratedMapData = useMemo(() => {
-    // API 데이터가 로딩 중이면 기존 MapData 사용
-    if (isApiLoading) {
+    // API 데이터가 로딩 중이거나 booths가 비어있으면 기존 MapData 사용
+    if (isApiLoading || booths.length === 0) {
       return MapData;
     }
 
     const apiMapData = convertApiDataToMapData();
 
+    // Booth API 데이터를 MapDataItem 형태로 변환
+    // /api/markers에서 주점 카테고리의 좌표 정보를 가져와서 매칭
+    const boothMarkers = apiMapData.filter((item: MapDataItem) => item.subtitle === '주점');
+
+    const boothApiData: MapDataItem[] = booths.map((booth) => {
+      // markers API에서 해당 주점의 좌표 정보 찾기
+      const markerInfo = boothMarkers.find((marker) => marker.id === booth.id);
+
+      return {
+        id: booth.id,
+        image: booth.profileImage,
+        title: booth.pubName,
+        subtitle: '주점',
+        time: markerInfo?.time || '18:00-24:00',
+        path: `/booth/${booth.id}`,
+        lat: markerInfo?.lat,
+        lng: markerInfo?.lng,
+        closeDay: markerInfo?.closeDay || [],
+        canPickup: booth.takeout, // 포장가능 정보 추가
+      };
+    });
+
     return {
       ...MapData,
       // API 데이터로 카테고리별 데이터 업데이트 (모든 카테고리 포함)
-      주점: apiMapData.filter((item: MapDataItem) => item.subtitle === '주점'),
+      주점: boothApiData, // Booth API 데이터 사용
       '주류 구매 위치': apiMapData.filter(
         (item: MapDataItem) => item.subtitle === '주류 구매 위치',
       ),
@@ -135,7 +160,7 @@ export default function Map() {
       의무실: apiMapData.filter((item: MapDataItem) => item.subtitle === '의무실'),
       AED: apiMapData.filter((item: MapDataItem) => item.subtitle === 'AED'),
     };
-  }, [convertApiDataToMapData, isApiLoading]);
+  }, [convertApiDataToMapData, isApiLoading, booths]);
 
   // 카카오맵 커스텀 훅 사용 - 단일 아이템 모드와 단일 아이템 데이터 전달
   const { moveToCurrentLocation, showItemMarker, kakaoMap } = useKakaoMap(
@@ -381,6 +406,11 @@ export default function Map() {
     moveToCurrentLocation(); // 현재 위치로 이동
   };
 
+  // 홈으로 이동 핸들러
+  const handleHomeClick = () => {
+    navigate('/');
+  };
+
   return (
     <S.MapContainer>
       <S.MapWrapper ref={mapRef} $isBottomSheetOpen={isBottomSheetOpen || !!selectedMapCategory} />
@@ -401,7 +431,7 @@ export default function Map() {
                 : selectedMapCategory // 카테고리 검색일 때는 카테고리명 표시
               : '지도'
           }
-          isClose={isFromSearchPage && selectedMapCategory ? true : false}
+          isClose={true} // 항상 X 버튼 표시
           backPath={isFromSearchPage && selectedMapCategory ? '/map/search' : undefined}
           onCloseClick={
             isFromSearchPage && selectedMapCategory
@@ -418,7 +448,7 @@ export default function Map() {
                   // URL에서 itemId 파라미터도 제거하면서 /map으로 이동
                   navigate('/map', { replace: true, state: { fromCloseClick: true } });
                 }
-              : undefined
+              : handleHomeClick // 일반적인 경우 홈으로 이동
           }
           opacity={isFromSearchPage && selectedMapCategory ? false : true}
           isSearchMode={isFromSearchPage && selectedMapCategory ? true : false}
@@ -463,11 +493,7 @@ export default function Map() {
               onItemClick={showItemMarker}
               selectedItemId={selectedItemId}
               customMapData={integratedMapData}
-            >
-              {selectedCategory === '주점' && (
-                <BoothList showFavoritesOnly={false} hideTabs={true} />
-              )}
-            </MapPageBottomSheet>
+            />
           </S.BottomSheetContainer>
         )}
       </S.ContentContainer>

--- a/src/services/noticeService.ts
+++ b/src/services/noticeService.ts
@@ -37,10 +37,12 @@ interface NoticeDetailResponse {
  */
 export const fetchNotices = async (): Promise<NoticeItem[]> => {
   try {
+    console.log('🔍 /api/notices GET 요청 시작');
     const response = await axiosInstance.get<NoticeListResponse>(`/api/notices`);
+    console.log('✅ /api/notices 응답:', response.data);
     return response.data.data;
   } catch (error) {
-    console.error('공지사항 목록을 가져오는데 실패했습니다:', error);
+    console.error('❌ 공지사항 목록을 가져오는데 실패했습니다:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## 📌 작업 내용 
- 바텀 시트가 올라와있을 때 화면 이동할 버튼이 없다고 하셔서 header에 X버튼 넣었습니다(/ 로 이동)
- 모바일에서 볼 때 바텀시트가 너무 높게 있다고 하셔서 기존에 바텀시트 올라오면 최대 3개 보이던 부분 2개 보이게 수정했습니다
- 주점 목록 찜하기 연동되게 추가했고 바텀시트 주점 목록 클릭하면 해당 id 주점 정보로 이동하게 수정했습니다

## 📸 스크린샷
<img width="561" height="1218" alt="image" src="https://github.com/user-attachments/assets/6a6429d7-3928-4523-9adf-ece3f1756f2c" />
<img width="558" height="1216" alt="image" src="https://github.com/user-attachments/assets/e1107cc7-975a-4a53-ae7f-9d2faf6dc06a" />
