### PR TITLE
fix: 주점 페이지 뒤로가기 무한 루프 해결

### DIFF
--- a/src/pages/booth/BoothDetail.tsx
+++ b/src/pages/booth/BoothDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { NavBar } from '@/components/nav-bar';
 import * as S from './BoothDetail.styles';
@@ -9,7 +9,15 @@ export default function BoothDetail() {
   const navigate = useNavigate();
   const { id } = useParams();
   const location = useLocation();
-  const fromRef = useRef(location.state?.from || '/booth');
+  const handleBackClick = () => {
+    const from = location.state?.from;
+    // 검색에서 온 경우에만 검색으로 돌아가기, 그 외에는 주점 메인으로
+    if (from === '/booth/search') {
+      navigate('/booth/search');
+    } else {
+      navigate('/booth');
+    }
+  };
   const { booth, error } = useBooth(Number(id) || 0);
 
   useEffect(() => {
@@ -30,7 +38,7 @@ export default function BoothDetail() {
 
   return (
     <S.Container>
-      <NavBar isBack hideRight title="주점 정보" backPath={fromRef.current} />
+      <NavBar isBack hideRight title="주점 정보" onBackClick={handleBackClick} />
       <S.BackgroundImg src={booth.posterImage} />
       <S.Section style={{ marginTop: '-2rem' }}>
         <BoothInfo id={booth.id} />

--- a/src/pages/booth/search/BoothSearch.tsx
+++ b/src/pages/booth/search/BoothSearch.tsx
@@ -14,7 +14,7 @@ export default function BoothSearch() {
   const { booths, loading } = useBooths();
   const [searchQuery, setSearchQuery] = useState('');
 
-  const handleCloseClick = () => {
+  const handleBackClick = () => {
     navigate('/booth');
   };
 
@@ -40,7 +40,7 @@ export default function BoothSearch() {
 
   return (
     <S.Container>
-      <NavBar isBack hideRight title="주점 검색" onCloseClick={handleCloseClick} />
+      <NavBar isBack hideRight title="주점 검색" onBackClick={handleBackClick} />
       <S.Main>
         <S.Content>
           <S.SearchSection>


### PR DESCRIPTION
## QA
 현재 설정된 플로우:
  1. 검색 페이지(/booth/search) → 상세 페이지(/booth/{id}) (state에 from:
  '/booth/search' 저장)
  2. 상세 페이지에서 뒤로가기 → 검색 페이지(/booth/search)로 돌아감
  3. 검색 페이지에서 뒤로가기 → 주점 메인(/booth)으로 이동