### PR TITLE
fix: 주점 관련 페이지 뒤로가기 버튼 상태관리(지도) 추가

### DIFF
--- a/src/features/map/bottomsheet/MapItemCard.tsx
+++ b/src/features/map/bottomsheet/MapItemCard.tsx
@@ -43,7 +43,9 @@ export function MapItemCard({ item, onItemClick, category }: MapItemCardProps) {
           onClick={() => {
             // 주점 카테고리인 경우 상세페이지로 이동
             if (category === '주점' && item.id) {
-              navigate(`/booth/${item.id}`);
+              navigate(`/booth/${item.id}`, {
+                state: { from: '/map', fromType: 'map' },
+              });
             } else if (onItemClick && item.lat && item.lng) {
               onItemClick(item);
             }

--- a/src/pages/booth/BoothDetail.tsx
+++ b/src/pages/booth/BoothDetail.tsx
@@ -11,10 +11,18 @@ export default function BoothDetail() {
   const location = useLocation();
   const handleBackClick = () => {
     const from = location.state?.from;
-    // 검색에서 온 경우에만 검색으로 돌아가기, 그 외에는 주점 메인으로
-    if (from === '/booth/search') {
+    const fromType = location.state?.fromType;
+
+    // 지도에서 온 경우 지도로 돌아가기
+    if (from === '/map' || fromType === 'map') {
+      navigate('/map');
+    }
+    // 검색에서 온 경우 검색으로 돌아가기
+    else if (from === '/booth/search') {
       navigate('/booth/search');
-    } else {
+    }
+    // 그 외에는 주점 메인으로
+    else {
       navigate('/booth');
     }
   };


### PR DESCRIPTION
## QA 해결 방안 
  1. MapItemCard.tsx: 주점 클릭 시 state에 지도에서 왔다는 정보 추가
  navigate(`/booth/${item.id}`, {
    state: { from: '/map', fromType: 'map' }
  });
  2. BoothDetail.tsx: 지도에서 온 경우를 최우선으로 처리하도록 수정
  // 지도에서 온 경우 지도로 돌아가기
  if (from === '/map' || fromType === 'map') {
    navigate('/map');