### PR TITLE
fix: 운세 카드 뒤집기 과정 오류 해결

### DIFF
--- a/src/pages/main/fortune/FortuneResult.styles.ts
+++ b/src/pages/main/fortune/FortuneResult.styles.ts
@@ -41,13 +41,16 @@ export const CardContainer = styled.div`
   perspective: 1000px;
 `;
 
-// 회전하는 박스
-export const CardInner = styled.button<{ $isFlipped: boolean; $isVisible: boolean }>`
+export const CardInner = styled.button<{
+  $isFlipped: boolean;
+  $isVisible: boolean;
+  $imageLoaded?: boolean;
+}>`
   -webkit-tap-highlight-color: transparent;
   appearance: none;
   border: 0;
   background: transparent;
-  cursor: pointer;
+  cursor: ${({ $imageLoaded }) => ($imageLoaded ? 'pointer' : 'default')};
   position: relative;
   width: 295px;
   height: 440px;
@@ -94,7 +97,6 @@ export const CardInner = styled.button<{ $isFlipped: boolean; $isVisible: boolea
   }
 `;
 
-// 앞/뒤 공통: 카드 면(겹쳐서 배치)
 const CardFace = styled.div`
   position: absolute;
   inset: 0;
@@ -120,7 +122,6 @@ export const CardFaceFront = styled(CardFace)`
   transform: rotateY(0deg);
 `;
 
-// CardContainer가 회전하면 정방향으로 보이도록
 export const CardFaceBack = styled(CardFace)`
   transform: rotateY(180deg);
 `;

--- a/src/pages/main/fortune/FortuneResult.tsx
+++ b/src/pages/main/fortune/FortuneResult.tsx
@@ -19,6 +19,7 @@ export default function FortuneResult() {
   const location = useLocation();
   const [isFlipped, setIsFlipped] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
 
   const state = location.state as LocationState;
   const selectedCardIndex = state?.selectedCardIndex ?? 0;
@@ -34,7 +35,9 @@ export default function FortuneResult() {
   };
 
   const handleCardClick = () => {
-    setIsFlipped(true);
+    if (imageLoaded) {
+      setIsFlipped(true);
+    }
   };
 
   useEffect(() => {
@@ -44,6 +47,21 @@ export default function FortuneResult() {
       setIsNav(true);
     };
   }, [setIsNav]);
+
+  useEffect(() => {
+    if (fortuneImageUrl) {
+      const img = new Image();
+      img.onload = () => setImageLoaded(true);
+      img.onerror = () => setImageLoaded(true);
+      img.src = fortuneImageUrl;
+
+      if (img.complete) {
+        setImageLoaded(true);
+      }
+    } else {
+      setImageLoaded(true);
+    }
+  }, [fortuneImageUrl]);
 
   return (
     <S.Container>
@@ -66,8 +84,10 @@ export default function FortuneResult() {
           <S.CardInner
             $isFlipped={isFlipped}
             $isVisible={isVisible}
+            $imageLoaded={imageLoaded}
             onClick={handleCardClick}
             aria-pressed={isFlipped}
+            disabled={!imageLoaded}
           >
             <S.CardFaceFront>
               <img


### PR DESCRIPTION
## 수정 방향
- 기존 구현의 문제점
    - 사용자 카드 클릭 -> 즉시 카드가 뒤집힘
    - 카드가 뒤집히는 **중간**에 이미지 다운로드 시도
    - 이미지 다운로드되는 시간동안 빈공간이나 깨진 이미지가 보임
    - 해당 문제로 인해 버퍼링처럼 보여지게 됨
- 개선
    -  페이지 로드 즉시 이미지를 백그라운드에서 미리 다운로드
    - 다운로드 후에만 카드 클릭 허용
    - 사용자가 클릭 -> 이미 준비된 이미지가 즉시 표시