### PR TITLE
fix: 주점 상세 페이지 이동시 로딩 화면 추가

### DIFF
--- a/src/features/booth/components/BoothList.tsx
+++ b/src/features/booth/components/BoothList.tsx
@@ -2,6 +2,7 @@ import * as S from './BoothList.styles';
 import { ImageTextFrameWithOrganization } from '@/components/image-text-frame';
 import { Notification } from '@/components/notification';
 import { FavoriteButton } from '@/components/favorite-button';
+import PageLoadingSpinner from '@/components/loading/PageLoadingSpinner';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Fragment } from 'react/jsx-runtime';
 import { useState } from 'react';
@@ -16,7 +17,7 @@ interface BoothListProps {
 export default function BoothList({ showFavoritesOnly = false, hideTabs = false }: BoothListProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const { booths, error } = useBooths();
+  const { booths, loading, error } = useBooths();
   const { isBoothNotificationClosed, closeBoothNotification } = useBoothNotificationStore();
 
   // 찜하기 기능 상태 관리 추가 (localStorage)
@@ -42,6 +43,10 @@ export default function BoothList({ showFavoritesOnly = false, hideTabs = false 
   const displayBooths = showFavoritesOnly
     ? booths.filter((booth) => favorites.includes(booth.id))
     : booths;
+
+  if (loading) {
+    return <PageLoadingSpinner />;
+  }
 
   if (error) {
     navigate('/error', {


### PR DESCRIPTION
## 구현 내용
- 주점 목록 -> 주점 상세페이지 이동 시 발생하는 깨짐현상 보완
- 로딩 상태 추가 
- 로딩 중일때, 기존 컴포넌트인 PageLoadingSpinner 표시