### PR TITLE
fix: update content carousel to autoplay and adjust z-index

### DIFF
--- a/src/features/main/components/carousels/EventCarousels.tsx
+++ b/src/features/main/components/carousels/EventCarousels.tsx
@@ -41,14 +41,19 @@ export default function EventCarousels({ events }: EventCarouselsProps) {
   // 아이템 개수에 상관없이 일관된 설정 적용
   const settings = {
     dots: false,
-    infinite: false,
-    speed: 500,
+    infinite: true,
+    speed: 1000,
     slidesToShow: 1,
     slidesToScroll: 1,
     arrows: false,
     centerMode: false,
     variableWidth: false,
     initialSlide: 0,
+
+    autoplay: true,
+    autoplaySpeed: 8000,
+    pauseOnFocus: true,
+    pauseOnHover: true,
 
     beforeChange: () => {
       isSwipingRef.current = true;

--- a/src/pages/main/Main.styles.ts
+++ b/src/pages/main/Main.styles.ts
@@ -16,7 +16,7 @@ export const TitleBar = styled.div`
   padding: 1.2rem;
   top: 0;
   left: 0;
-  z-index: 10;
+  z-index: 999;
   box-shadow: 0 0 0.5rem 0 ${(props) => props.theme.colors.primary.violet};
 `;
 


### PR DESCRIPTION
## 🔥 PR 제목  

fix: update content carousel to autoplay and adjust z-index

## 📌 작업 내용  

- 메인 화면 진행중인 콘텐츠 캐러셀에 자동 스와이프 활성화 (8초 간격, 호버링 & 포커스시 일시 정지)
- 캐러셀 Index Pill이 상단 Navbar 위를 넘는 이슈 z-index 수정으로 해결

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  