### PR TITLE
fix: correct webkit-box display property for text ellipsis

### DIFF
--- a/src/features/main/components/notice/NoticeText.styles.ts
+++ b/src/features/main/components/notice/NoticeText.styles.ts
@@ -51,7 +51,7 @@ export const body = styled.p`
   align-self: stretch;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: ${'box'};
+  display: -webkit-box; /* stylelint-disable-line value-no-vendor-prefix */
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   word-break: break-word;


### PR DESCRIPTION
## 🔥 PR 제목  

fix: correct webkit-box display property for text ellipsis

## 📌 작업 내용  

- 공지 목록에서 ellipsis 정상적 표시 위해 webkit-box로 속성 변경

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  