### PR TITLE
fix: 주점 상세페이지 및 지도 뒤로가기 버튼 로직 추가

### DIFF
--- a/src/features/booth/components/BoothLocation.tsx
+++ b/src/features/booth/components/BoothLocation.tsx
@@ -90,7 +90,16 @@ export default function BoothLocation({
       <S.Title>위치</S.Title>
       <S.Locate>{boothLocation.replace('.', '-')}</S.Locate>
       <S.Map ref={mapRef}>
-        <S.Button onClick={() => navigate(`/map/${id}`, { replace: true })}>
+        <S.Button
+          onClick={() =>
+            navigate(`/map/${id}`, {
+              state: {
+                from: `/booth/${id}`,
+                fromType: 'booth-detail',
+              },
+            })
+          }
+        >
           <S.ButtonText>지도에서 보기</S.ButtonText>
           <RightIcon width="0.55rem" height="0.55rem" />
         </S.Button>

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -480,7 +480,10 @@ export default function Map() {
           isClose={true} // 항상 X 버튼 표시
           backPath={isFromSearchPage && selectedMapCategory ? '/map/search' : undefined}
           onCloseClick={() => {
-            if (isFromSearchPage && selectedMapCategory) {
+            // 주점 상세 페이지에서 온 경우: 주점 상세로 돌아가기
+            if (location.state?.fromType === 'booth-detail' && location.state?.from) {
+              navigate(location.state.from);
+            } else if (isFromSearchPage && selectedMapCategory) {
               // 검색 페이지에서 온 경우: 검색 상태 초기화 후 /map으로 이동
               setSelectedMapCategory(() => '');
               setSelectedCategory(() => null);


### PR DESCRIPTION
## 구현 내용
- 주점 상세 페이지 -> 지도에서 보기 버튼 -> 뒤로가기 -> 지도 검색 페이지로 이동 (기대: 주점 상세 페이지로 이동) 은 QA엔 없었지만, 지금 상태 관리 로직을 별도로 추가