### PR TITLE
fix: disable test log and make error page button action to refresh

### DIFF
--- a/src/pages/error/ErrorPage.tsx
+++ b/src/pages/error/ErrorPage.tsx
@@ -52,7 +52,9 @@ const ErrorPage = ({
         </S.ErrorIconWrapper>
         <S.ErrorMainText>{mainText}</S.ErrorMainText>
         {subText ? <S.ErrorSubText>{subText}</S.ErrorSubText> : <br />}
-        {showHomeButton && <AccentButton onClick={() => navigate('/')} label="홈으로 가기" />}
+        {showHomeButton && (
+          <AccentButton onClick={() => (window.location.href = '/')} label="홈으로 가기" />
+        )}
       </S.ErrorContent>
     </S.ErrorPageContainer>
   );

--- a/src/services/noticeService.ts
+++ b/src/services/noticeService.ts
@@ -37,9 +37,9 @@ interface NoticeDetailResponse {
  */
 export const fetchNotices = async (): Promise<NoticeItem[]> => {
   try {
-    console.log('🔍 /api/notices GET 요청 시작');
+    // console.log('🔍 /api/notices GET 요청 시작');
     const response = await axiosInstance.get<NoticeListResponse>(`/api/notices`);
-    console.log('✅ /api/notices 응답:', response.data);
+    // console.log('✅ /api/notices 응답:', response.data);
     return response.data.data;
   } catch (error) {
     console.error('❌ 공지사항 목록을 가져오는데 실패했습니다:', error);


### PR DESCRIPTION
## 🔥 PR 제목  

fix: disable test log and make error page button action to refresh

## 📌 작업 내용  

- 에러 페이지에서 `홈으로 가기` 버튼 누를시 SPA 라우팅이 아니라 실제 리프레시가 이뤄지도록 수정

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  