### PR TITLE
fix: remove unnecessary help icon from AppInstallPrompt & change TitleBar z-index

### DIFF
--- a/src/features/main/components/user/AppInstallPrompt.tsx
+++ b/src/features/main/components/user/AppInstallPrompt.tsx
@@ -96,7 +96,6 @@ function AppInstallPromptModal({
       >
         <S.ModalTab>
           <S.ModalTitle>
-            {<S.Help fill="#000000bd" width={18} height={18} />}
             <S.ModalTitleText>홈 화면 추가하기</S.ModalTitleText>
           </S.ModalTitle>
           <S.ModalCloseBtn onClick={handleCancelClick} fill="#17171B" width={18} height={18} />

--- a/src/pages/main/Main.styles.ts
+++ b/src/pages/main/Main.styles.ts
@@ -18,7 +18,7 @@ export const TitleBar = styled.div`
   padding: 1.2rem;
   top: 0;
   left: 0;
-  z-index: 999;
+  z-index: 900;
   box-shadow: 0 0 0.5rem 0 ${(props) => props.theme.colors.primary.violet};
 `;
 


### PR DESCRIPTION
## 🔥 PR 제목  

fix: remove unnecessary help icon from AppInstallPrompt & change TitleBar z-index

## 📌 작업 내용  

- PWA 설치유도 팝업에서 물음표 아이콘 제거
- TitleBar z-index 수정 (999 -> 990)

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

<img width="523" height="1082" alt="image" src="https://github.com/user-attachments/assets/f2398dae-a724-42a6-a3f3-af00b184b51c" />

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  