### PR TITLE
refactor: 바텀시트 뒤로가기 로직 수정

### DIFF
--- a/src/features/map/bottomsheet/MapItemCard.tsx
+++ b/src/features/map/bottomsheet/MapItemCard.tsx
@@ -44,7 +44,7 @@ export function MapItemCard({ item, onItemClick, category }: MapItemCardProps) {
             // 주점 카테고리인 경우 상세페이지로 이동
             if (category === '주점' && item.id) {
               navigate(`/booth/${item.id}`, {
-                state: { from: '/map', fromType: 'map' },
+                state: { from: '/map', fromType: 'map', category: category },
               });
             } else if (onItemClick && item.lat && item.lng) {
               onItemClick(item);
@@ -79,11 +79,15 @@ export function MapItemCard({ item, onItemClick, category }: MapItemCardProps) {
       onClick={() => {
         // path 필드가 있으면 해당 경로로 이동
         if (item.path) {
-          navigate(item.path);
+          navigate(item.path, {
+            state: { from: '/map', fromType: 'map', category: category },
+          });
         }
         // path가 없을 때 linkType과 linkId를 기반으로 동적 라우팅 (fallback)
         else if (item.linkType === 'NOTICE_DETAIL' && item.linkId) {
-          navigate(`/main/notice/${item.linkId}`);
+          navigate(`/main/notice/${item.linkId}`, {
+            state: { from: '/map', fromType: 'map', category: category },
+          });
         } else if (onItemClick && item.lat && item.lng) {
           onItemClick(item);
         }

--- a/src/pages/booth/BoothDetail.tsx
+++ b/src/pages/booth/BoothDetail.tsx
@@ -13,10 +13,15 @@ export default function BoothDetail() {
   const handleBackClick = () => {
     const from = location.state?.from;
     const fromType = location.state?.fromType;
+    const category = location.state?.category;
 
-    // 지도에서 온 경우 지도로 돌아가기
+    // 지도에서 온 경우 지도로 돌아가기 (카테고리 정보 포함)
     if (from === '/map' || fromType === 'map') {
-      navigate('/map');
+      if (category) {
+        navigate(`/map?category=${encodeURIComponent(category)}`);
+      } else {
+        navigate('/map');
+      }
     }
     // 검색에서 온 경우 검색으로 돌아가기
     else if (from === '/booth/search') {

--- a/src/pages/main/notice/NoticeDetail.tsx
+++ b/src/pages/main/notice/NoticeDetail.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { NavBar } from '@/components/nav-bar';
 import * as S from './NoticeDetail.styles';
 import { useEffect, useState } from 'react';
@@ -27,6 +27,7 @@ export default function NoticeDetail() {
 
   const setIsNav = useLayoutStore((state) => state.setIsNav);
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     setIsNav(false);
@@ -97,10 +98,26 @@ export default function NoticeDetail() {
     });
   }
 
+  const handleBackClick = () => {
+    const from = location.state?.from;
+    const fromType = location.state?.fromType;
+    const category = location.state?.category;
+
+    if (from === '/map' || fromType === 'map') {
+      if (category) {
+        navigate(`/map?category=${encodeURIComponent(category)}`);
+      } else {
+        navigate('/map');
+      }
+    } else {
+      navigate('/main/notice');
+    }
+  };
+
   if (!notice) return null;
   return (
     <>
-      <NavBar title="공지사항" isBack={true} />
+      <NavBar title="공지사항" isBack={true} onBackClick={handleBackClick} />
       <S.Container>
         <NoticeDetailCarousels img={notice.img} />
         <NoticeBody title={notice.title} tags={notice.tags} body={notice.body} />

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
-import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useNavigate, useParams, useLocation, useSearchParams } from 'react-router-dom';
 import { MapPageBottomSheet } from '@/features/map';
 import { NavBar } from '@/components/nav-bar';
 import { Tabs } from '@/components/tabs';
@@ -23,6 +23,7 @@ export default function Map() {
   const itemId = itemIdParam ? Number(itemIdParam) : undefined;
   const navigate = useNavigate();
   const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
   const mapRef = useRef<HTMLDivElement>(null);
 
   // 현재 날짜에 기반한 페스티벌 일차 계산 (한국 시간 기준)
@@ -32,6 +33,8 @@ export default function Map() {
   const [selectedDay, setSelectedDay] = useState<DAYS>(currentDay);
   const [selectedCategory, setSelectedCategory] = useState<CATEGORIES | null>(null);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState<boolean>(false);
+
+  const categoryFromUrl = searchParams.get('category');
 
   // 지도 카테고리 상태
   const [selectedMapCategory, setSelectedMapCategory] = useState<string>('');
@@ -378,6 +381,17 @@ export default function Map() {
     }
   }, [fetchMarkers, isInitialized]);
 
+  useEffect(() => {
+    if (categoryFromUrl && !selectedMapCategory && !isApiLoading) {
+      const mappedCategory = categoryMapping[categoryFromUrl];
+      if (mappedCategory) {
+        setSelectedMapCategory(categoryFromUrl);
+        setSelectedCategory(mappedCategory);
+        setIsBottomSheetOpen(true);
+      }
+    }
+  }, [categoryFromUrl, selectedMapCategory, isApiLoading, categoryMapping]);
+
   // 에러 발생 시 에러 페이지로 이동
   useEffect(() => {
     if (markerError) {
@@ -440,6 +454,8 @@ export default function Map() {
     if (newCategory) {
       const mappedCategory = categoryMapping[newCategory];
       setSelectedCategory(mappedCategory);
+
+      setSearchParams({ category: newCategory });
     } else {
       setSelectedCategory(null);
       setSelectedItemId(null);
@@ -447,6 +463,8 @@ export default function Map() {
       setSingleItemMode(false);
       setSingleItem(null);
       setSingleItemSearchKeyword('');
+
+      setSearchParams({});
     }
   };
 


### PR DESCRIPTION
## 📌 작업 내용  
- 지도페이지 바텀시트를 통해 이동했을 때 뒤로 가기를 눌렀을 경우 url 쿼리 파라미터를 통해 상태 유지하도록 수정했습니
## 📸 스크린샷
<img width="558" height="1206" alt="image" src="https://github.com/user-attachments/assets/cd9bb968-b86c-4c48-a30a-086fcef10732" />
<img width="558" height="1211" alt="image" src="https://github.com/user-attachments/assets/a7d0f47b-9f3e-44d3-a225-63fbe50f61b6" />
