### PR TITLE
fix: navigation infinite loop in notice pages

### DIFF
--- a/src/pages/main/notice/Notice.tsx
+++ b/src/pages/main/notice/Notice.tsx
@@ -76,9 +76,13 @@ export default function Notice() {
     [navigate],
   );
 
+  const handleBackClick = () => {
+    navigate('/main');
+  };
+
   return (
     <>
-      <NavBar title="공지사항" isBack={true} />
+      <NavBar title="공지사항" isBack={true} onBackClick={handleBackClick} />
       <S.Container>
         {loading ? (
           <S.LoadingWrapper>공지사항을 불러오는 중...</S.LoadingWrapper>


### PR DESCRIPTION
## 🔥 PR 제목  

fix: navigation infinite loop in notice pages

## 📌 작업 내용  

- 공지 목록 -> 공지 세부에서 뒤로가면서 무한 네비게이션 루프에 빠지는 문제 해결

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  